### PR TITLE
python doctest style testing in docco?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 output
 docs
+test/*_examples.coffee

--- a/bin/docco
+++ b/bin/docco
@@ -4,5 +4,5 @@ var path = require('path');
 var fs = require('fs');
 var lib = path.join(path.dirname(__filename), '../lib');
 
-process.ARGV = process.argv = process.argv.slice(2, process.argv.length);
-require(lib + '/docco.js');
+var docco = require(lib + '/docco.js');
+docco.generate(process.argv.slice(2, process.argv.length));

--- a/lib/docco.js
+++ b/lib/docco.js
@@ -1,29 +1,32 @@
 (function() {
-  var _a, _b, _c, destination, docco_styles, docco_template, ensure_directory, exec, ext, fs, generate_documentation, generate_html, get_language, highlight, highlight_end, highlight_start, l, languages, parse, path, print, puts, showdown, sources, spawn, template;
+  var _a, _b, _c, destination, docco_styles, docco_template, ensure_directories, exec, ext, fs, generate_documentation, generate_html, generate_tests, get_language, highlight, highlight_end, highlight_start, l, languages, parse, path, print, puts, showdown, spawn, template, test_destination;
   var __hasProp = Object.prototype.hasOwnProperty;
-  generate_documentation = function(source, callback) {
+  generate_documentation = function(source, sources, callback) {
     return fs.readFile(source, "utf-8", function(error, code) {
       var sections;
       if (error) {
         throw error;
       }
       sections = parse(source, code);
+      puts(("docco: " + (source)));
       return highlight(source, sections, function() {
-        generate_html(source, sections);
+        generate_html(source, sources, sections);
+        generate_tests(source, sections);
         return callback();
       });
     });
   };
-  parse = function(source, code) {
-    var _a, _b, _c, code_text, docs_text, has_code, language, line, lines, save, sections;
+  exports.parse = (parse = function(source, code) {
+    var _a, _b, _c, code_text, docs_text, has_code, language, line, lines, save, sections, test_text;
     lines = code.split('\n');
     sections = [];
     language = get_language(source);
-    has_code = (docs_text = (code_text = ''));
-    save = function(docs, code) {
+    has_code = (docs_text = (code_text = (test_text = '')));
+    save = function() {
       return sections.push({
-        docs_text: docs,
-        code_text: code
+        docs: docs_text,
+        code: code_text,
+        test: test_text
       });
     };
     _b = lines;
@@ -31,18 +34,20 @@
       line = _b[_a];
       if (line.match(language.comment_matcher)) {
         if (has_code) {
-          save(docs_text, code_text);
-          has_code = (docs_text = (code_text = ''));
+          save();
+          has_code = (docs_text = (test_text = (code_text = '')));
         }
-        docs_text += line.replace(language.comment_matcher, '') + '\n';
+        line = line.replace(language.comment_matcher, '') + '\n';
+        docs_text += line;
+        line.match(/^( {4}|\t)[^>]/) ? test_text += line.replace(/^( {4}|\t)/, '') : null;
       } else {
         has_code = true;
         code_text += line + '\n';
       }
     }
-    save(docs_text, code_text);
+    save();
     return sections;
-  };
+  });
   highlight = function(source, sections, callback) {
     var _a, _b, _c, _d, language, output, pygments, section;
     language = get_language(source);
@@ -66,7 +71,7 @@
       for (i = 0, _b = _a.length; i < _b; i++) {
         section = _a[i];
         section.code_html = highlight_start + fragments[i] + highlight_end;
-        section.docs_html = showdown.makeHtml(section.docs_text);
+        section.docs_html = showdown.makeHtml(section.docs);
       }
       return callback();
     });
@@ -74,13 +79,13 @@
       _a = []; _c = sections;
       for (_b = 0, _d = _c.length; _b < _d; _b++) {
         section = _c[_b];
-        _a.push(section.code_text);
+        _a.push(section.code);
       }
       return _a;
     })().join(language.divider_text));
     return pygments.stdin.end();
   };
-  generate_html = function(source, sections) {
+  generate_html = function(source, sources, sections) {
     var dest, html, title;
     title = path.basename(source);
     dest = destination(source);
@@ -91,8 +96,27 @@
       path: path,
       destination: destination
     });
-    puts("docco: " + (source) + " -> " + (dest));
+    puts(("  -> " + (dest)));
     return fs.writeFile(dest, html);
+  };
+  generate_tests = function(source, sections) {
+    var _a, _b, _c, comment, dest, fd, language, section;
+    dest = test_destination(source);
+    language = get_language(source);
+    puts(("  -> " + (dest)));
+    fd = fs.openSync(dest, 'w+');
+    _b = sections;
+    for (_a = 0, _c = _b.length; _a < _c; _a++) {
+      section = _b[_a];
+      if (section.test) {
+        comment = section.code == undefined ? undefined : section.code.split("\n")[0];
+        if (comment) {
+          fs.writeSync(fd, ("" + (language.symbol) + " ## " + (comment) + "\n"));
+        }
+        fs.writeSync(fd, section.test + "\n\n");
+      }
+    }
+    return fs.closeSync(fd);
   };
   fs = require('fs');
   path = require('path');
@@ -110,11 +134,11 @@
     },
     '.js': {
       name: 'javascript',
-      symbol: '//'
-    },
-    '.rb': {
-      name: 'ruby',
-      symbol: '#'
+      symbol: '//',
+      '.rb': {
+        name: 'ruby',
+        symbol: '#'
+      }
     }
   };
   _c = languages;
@@ -131,8 +155,11 @@
   destination = function(filepath) {
     return 'docs/' + path.basename(filepath, path.extname(filepath)) + '.html';
   };
-  ensure_directory = function(callback) {
-    return exec('mkdir -p docs', function() {
+  test_destination = function(filepath) {
+    return 'test/' + path.basename(filepath, path.extname(filepath)) + '_examples' + path.extname(filepath);
+  };
+  ensure_directories = function(callback) {
+    return exec('mkdir -p docs test', function() {
       return callback();
     });
   };
@@ -143,18 +170,17 @@
   docco_styles = fs.readFileSync(__dirname + '/../resources/docco.css').toString();
   highlight_start = '<div class="highlight"><pre>';
   highlight_end = '</pre></div>';
-  sources = process.ARGV.sort();
-  if (sources.length) {
-    ensure_directory(function() {
+  exports.generate = function(sources) {
+    return ensure_directories(function() {
       var files, next_file;
       fs.writeFile('docs/docco.css', docco_styles);
       files = sources.slice(0);
       next_file = function() {
         if (files.length) {
-          return generate_documentation(files.shift(), next_file);
+          return generate_documentation(files.shift(), sources, next_file);
         }
       };
       return next_file();
     });
-  }
+  };
 })();

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -7,7 +7,7 @@
 #
 # If you install Docco, you can run it from the command-line:
 #
-#     docco src/*.coffee
+#     > docco src/*.coffee
 #
 # ...will generate linked HTML documentation for the named source files, saving
 # it into a `docs` folder.
@@ -17,7 +17,7 @@
 # from [its Mercurial repo](http://dev.pocoo.org/hg/pygments-main)), and
 # [CoffeeScript](http://coffeescript.org/). Then, with NPM:
 #
-#     sudo npm install docco
+#     > sudo npm install docco
 #
 # If **Node.js** doesn't run on your platform, or you'd prefer a more convenient
 # package, get [Rocco](http://rtomayko.github.com/rocco/), the Ruby port that's
@@ -27,49 +27,75 @@
 # your speed, take a look at [Nick Fitzgerald](http://github.com/fitzgen)'s
 # [Pycco](http://fitzgen.github.com/pycco/).
 
+#### Examples and Usage
+
+# Generally, docco will be used from the command line.
+#
+#     > docco foo.js
+#
+# However, it can also be used from code.
+#
+#     assert = require 'assert'
+#     path = require 'path'
+#     assertPathExists = (p) -> assert.ok path.existsSync(p), p
+#     
+#     docco = require 'docco'
+#     docco.generate ['src/docco.coffee']
+#     assertPathExists 'test/docco_examples.coffee'
+#     assertPathExists 'docs/docco.html'
+
 #### Main Documentation Generation Functions
 
 # Generate the documentation for a source file by reading it in, splitting it
 # up into comment/code sections, highlighting them for the appropriate language,
 # and merging them into an HTML template.
-generate_documentation = (source, callback) ->
+generate_documentation = (source, sources, callback) ->
   fs.readFile source, "utf-8", (error, code) ->
     throw error if error
     sections = parse source, code
+    puts "docco: #{source}"
     highlight source, sections, ->
-      generate_html source, sections
+      generate_html source, sources, sections
+      generate_tests source, sections
       callback()
 
 # Given a string of source code, parse out each comment and the code that
 # follows it, and create an individual **section** for it.
-# Sections take the form:
 #
-#     {
-#       docs_text: ...
-#       docs_html: ...
-#       code_text: ...
-#       code_html: ...
-#     }
+# Examples:
 #
-parse = (source, code) ->
+#     parsed = docco.parse "example.coffee", """
+#       # Some docs.
+#       #     assert.ok 'a test'
+#       myCode()"""
+#     assert.deepEqual parsed, [{
+#       docs: "Some docs.\n    assert.ok 'a test'\n",
+#       test: "assert.ok 'a test'\n",
+#       code: "myCode()\n" }]
+exports.parse = parse = (source, code) ->
   lines    = code.split '\n'
   sections = []
   language = get_language source
-  has_code = docs_text = code_text = ''
+  has_code = docs_text = code_text = test_text = ''
 
-  save = (docs, code) ->
-    sections.push docs_text: docs, code_text: code
+  save = ->
+    sections.push docs: docs_text, code: code_text, test: test_text
 
   for line in lines
     if line.match language.comment_matcher
       if has_code
-        save docs_text, code_text
-        has_code = docs_text = code_text = ''
-      docs_text += line.replace(language.comment_matcher, '') + '\n'
+        save()
+        has_code = docs_text = test_text = code_text = ''
+
+      line = line.replace(language.comment_matcher, '') + '\n'
+      docs_text += line
+
+      if line.match /^( {4}|\t)[^>]/
+        test_text += line.replace(/^( {4}|\t)/, '')
     else
       has_code = yes
       code_text += line + '\n'
-  save docs_text, code_text
+  save()
   sections
 
 # Highlights a single chunk of CoffeeScript code, using **Pygments** over stdio,
@@ -92,22 +118,33 @@ highlight = (source, sections, callback) ->
     fragments = output.split language.divider_html
     for section, i in sections
       section.code_html = highlight_start + fragments[i] + highlight_end
-      section.docs_html = showdown.makeHtml section.docs_text
+      section.docs_html = showdown.makeHtml section.docs
     callback()
-  pygments.stdin.write((section.code_text for section in sections).join(language.divider_text))
+  pygments.stdin.write((section.code for section in sections).join(language.divider_text))
   pygments.stdin.end()
 
 # Once all of the code is finished highlighting, we can generate the HTML file
 # and write out the documentation. Pass the completed sections into the template
 # found in `resources/docco.jst`
-generate_html = (source, sections) ->
+generate_html = (source, sources, sections) ->
   title = path.basename source
   dest  = destination source
   html  = docco_template {
     title: title, sections: sections, sources: sources, path: path, destination: destination
   }
-  puts "docco: #{source} -> #{dest}"
+  puts "  -> #{dest}"
   fs.writeFile dest, html
+
+generate_tests = (source, sections) ->
+  dest = test_destination source
+  language = get_language source
+  puts "  -> #{dest}"
+  fd = fs.openSync dest, 'w+'
+  for section in sections when section.test
+    comment = section.code?.split("\n")[0]
+    fs.writeSync fd, "#{language.symbol} ## #{comment}\n" if comment
+    fs.writeSync fd, section.test + "\n\n"
+  fs.closeSync fd
 
 #### Helpers & Setup
 
@@ -152,9 +189,12 @@ get_language = (source) -> languages[path.extname(source)]
 destination = (filepath) ->
   'docs/' + path.basename(filepath, path.extname(filepath)) + '.html'
 
+test_destination = (filepath) ->
+  'test/' + path.basename(filepath, path.extname(filepath)) + '_examples' + path.extname(filepath)
+
 # Ensure that the destination directory exists.
-ensure_directory = (callback) ->
-  exec 'mkdir -p docs', -> callback()
+ensure_directories = (callback) ->
+  exec 'mkdir -p docs test', -> callback()
 
 # Micro-templating, originally by John Resig, borrowed by way of
 # [Underscore.js](http://documentcloud.github.com/underscore/).
@@ -183,13 +223,11 @@ highlight_start = '<div class="highlight"><pre>'
 # The end of each Pygments highlight block.
 highlight_end   = '</pre></div>'
 
-# Run the script.
 # For each source file passed in as an argument, generate the documentation.
-sources = process.ARGV.sort()
-if sources.length
-  ensure_directory ->
+exports.generate = (sources) ->
+  ensure_directories ->
     fs.writeFile 'docs/docco.css', docco_styles
     files = sources.slice(0)
-    next_file = -> generate_documentation files.shift(), next_file if files.length
+    next_file = -> generate_documentation files.shift(), sources, next_file if files.length
     next_file()
 


### PR DESCRIPTION
Hey Jeremy,

I decided I wanted to give literate testing a try (have been annoyed one too many times by RSpec), and figured it'd be nice to add python doctest style testing to docco.

So I did it.  I also added a handful of tests for docco itself in the process.

This is a v0 release.  Basically all it does is take the code from the comments and exports it into `tests/` so they can be run.  I figured it'd be enough to determine if the functionality is useful.

Sending the pull request mostly as an FYI.  Would appreciate your thoughts.  No real need to merge in the code (though it'd be fine if you chose to do so).

Best,
Gerad
