### PR TITLE
Added support to pass in your own css

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -143,18 +143,31 @@
   docco_styles = fs.readFileSync(__dirname + '/../resources/docco.css').toString();
   highlight_start = '<div class="highlight"><pre>';
   highlight_end = '</pre></div>';
-  sources = process.ARGV.sort();
+  sources = process.ARGV;
   if (sources.length) {
     ensure_directory(function() {
-      var files, next_file;
+      var args, next_arg;
       fs.writeFile('docs/docco.css', docco_styles);
-      files = sources.slice(0);
-      next_file = function() {
-        if (files.length) {
-          return generate_documentation(files.shift(), next_file);
+      args = sources.slice(0);
+      next_arg = function() {
+        var a, cssExtension, new_styles;
+        if (args.length) {
+          a = args.shift();
+          if (a === "-c" || a === "--css") {
+            a = args.shift();
+            cssExtension = a.search(/.css$/i);
+            if (cssExtension !== -1) {
+              docco_styles = fs.readFileSync(__dirname + '/../resources/docco.css').toString();
+              new_styles = fs.readFileSync(fs.realpathSync(a)).toString();
+              fs.writeFile('docs/docco.css', docco_styles + "\n" + new_styles);
+              next_arg();
+              return;
+            }
+          }
+          return generate_documentation(a, next_arg);
         }
       };
-      return next_file();
+      return next_arg();
     });
   }
 }).call(this);

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -196,11 +196,22 @@ highlight_end   = '</pre></div>'
 
 # Run the script.
 # For each source file passed in as an argument, generate the documentation.
-sources = process.ARGV.sort()
+sources = process.ARGV
 if sources.length
   ensure_directory ->
     fs.writeFile 'docs/docco.css', docco_styles
-    files = sources.slice(0)
-    next_file = -> generate_documentation files.shift(), next_file if files.length
-    next_file()
+    args = sources.slice(0)
+    next_arg = -> 
+        if args.length
+            a = args.shift()
+            if a is "-c" || a is "--css"
+                a = args.shift()
+                cssExtension = a.search /.css$/i
+                if cssExtension isnt -1
+                    new_styles = fs.readFileSync(fs.realpathSync(a)).toString()
+                    fs.writeFile 'docs/docco.css', docco_styles+"\n"+new_styles
+                    next_arg()
+                    return
+            generate_documentation a, next_arg
+    next_arg()
 


### PR DESCRIPTION
To prevent your styles from being overwritten every time your run docco, you can now pass in your own styles via -c or --css (ie: docco -c style.css src/*.as). Also added ActionScript file support.
