### PR TITLE
Add support for Haskell

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -111,6 +111,10 @@
     '.py': {
       name: 'python',
       symbol: '#'
+    },
+    '.hs': {
+      name: 'haskell',
+      symbol: '--'
     }
   };
   for (ext in languages) {

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -133,6 +133,8 @@ languages =
     name: 'ruby', symbol: '#'
   '.py':
     name: 'python', symbol: '#'
+  '.hs':
+    name: 'haskell', symbol: '--'
 
 # Build out the appropriate matchers and delimiters for each language.
 for ext, l of languages


### PR DESCRIPTION
Haskell works right out of the box as it is supported by Pygments.

This does not add support for Literate Haskell, where code lines are prefixed with the symbol `>` and "comment" lines are not prefixed at all. This should preferably be added, but won't conflict with this patch since literate Haskell files have a separate filename suffix `.lhs` by convention.

ps. there were some other changes in docco.js after I ran cake, presumably because I use a different version of Coffee Script. I did not include those chunks (and the script works the same regardless).
