### PR TITLE
Report error when pygments isn't installed

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -52,7 +52,7 @@
       }
     });
     pygments.stdin.addListener('error', function(error) {
-      console.error("Error trying to run pygmentized to hilight the source. Do you have it installed?");
+      console.error("Error trying to run pygmentized to highlight the source. Do you have it installed?");
       return process.exit(1);
     });
     pygments.stdout.addListener('data', function(result) {

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -105,7 +105,7 @@ highlight = (source, sections, callback) ->
   pygments.stderr.addListener 'data',  (error)  ->
     console.error error if error
   pygments.stdin.addListener 'error',  (error)  ->
-    console.error "Error trying to run pygmentized to hilight the source. Do you have it installed?"
+    console.error "Error trying to run pygmentized to highlight the source. Do you have it installed?"
     process.exit 1
   pygments.stdout.addListener 'data', (result) ->
     output += result if result


### PR DESCRIPTION
I modified the highlight method to report a more helpful error if it can't spawn pygmentize.
