### PR TITLE
highlight: Run toString('ascii') on error before printing it

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -48,7 +48,13 @@
     output = '';
     pygments.stderr.addListener('data', function(error) {
       if (error) {
-        return console.error(error);
+        if (typeof error !== 'string') {
+          return console.error(error.toString('ascii'));
+        } else {
+          if (error) {
+            return console.error(error);
+          }
+        }
       }
     });
     pygments.stdin.addListener('error', function(error) {

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -105,8 +105,12 @@ highlight = (source, sections, callback) ->
   output   = ''
   
   pygments.stderr.addListener 'data',  (error)  ->
-    console.error error if error
-    
+    if error
+      if typeof error != 'string'
+        console.error error.toString('ascii')
+      else
+        console.error error
+
   pygments.stdin.addListener 'error',  (error)  ->
     console.error "Could not use Pygments to highlight the source."
     process.exit 1


### PR DESCRIPTION
This way we get (for example)

```
*** Error while highlighting:
TypeError: Can't convert 'bytes' object to str implicitly
   (file "/usr/lib/python3.2/codecs.py", line 355, in write)
```

instead of 

```
<Buffer 0a 2a 2a 2a 20 45 72 72 6f 72 20 77 68 69 6c 65 20 68 69 67 68 6c 69 67 68 74 69 6e 67 3a 0a 54 79 70 65 45 72 72 6f 72 3a 20 43 61 6e 27 74 20 63 6f 6e 76 65 72 74 20 27 62 79 74 65 73 27 20 6f 62 6a 65 63 74 20 74 6f 20 73 74 72 20 69 6d 70 6c 69 63 69 74 6c 79 0a 20 20 20 28 66 69 6c 65 20 22 2f 75 73 72 2f 6c 69 62 2f 70 79 74 68 6f 6e 33 2e 32 2f 63 6f 64 65 63 73 2e 70 79 22 2c 20 6c 69 6e 65 20 33 35 35 2c 20 69 6e 20 77 72 69 74 65 29 0a>
```

FYI: The error message is a bug in pygmentize when used with python3: https://bitbucket.org/birkenfeld/pygments-main/issue/691/utf-8-encoding-via-pygmentize-raises
