### PR TITLE
Keyboard navigation

### DIFF
--- a/resources/docco.css
+++ b/resources/docco.css
@@ -47,14 +47,17 @@ h1, h2, h3, h4, h5, h6 {
 }
   #jump_wrapper {
     padding: 0;
-    display: none;
   }
-    #jump_to:hover #jump_wrapper {
-      display: block;
-    }
     #jump_page {
       padding: 5px 0 3px;
       margin: 0 0 25px 25px;
+    }
+    #jump_page.hidden {
+      position: absolute;
+      left: -9999px;
+    }
+    #jump_to:hover #jump_page {
+      position: static;
     }
       #jump_page .source {
         display: block;
@@ -62,6 +65,7 @@ h1, h2, h3, h4, h5, h6 {
         text-decoration: none;
         border-top: 1px solid #eee;
       }
+        #jump_page .source:focus,
         #jump_page .source:hover {
           background: #f5f5ff;
         }

--- a/resources/docco.jst
+++ b/resources/docco.jst
@@ -54,5 +54,24 @@
       </tbody>
     </table>
   </div>
+  <% if (sources.length > 1) { %>
+    <script>
+      (function(doc) {
+        var nav = doc.getElementById('jump_page');
+        if (!nav) return;
+
+        var links = nav.getElementsByTagName('a');
+        nav.className += ' hidden';
+
+        var onfocus = function() { nav.className = nav.className.replace(/(^|\s+)hidden(\s+|$)/, ' '); },
+          onblur = function() { nav.className += ' hidden'; };
+
+        for (var l = links.length; l--;) {
+          links[l].onfocus = onfocus;
+          links[l].onblur = onblur;
+        }
+      })(document)
+    </script>
+  <% } %>
 </body>
 </html>


### PR DESCRIPTION
CSS tweaks + simple `<script>` tag to enable smooth keyboard navigation of pilcrows and “Jump to…” links.
