### PR TITLE
Default tabs to 2 spaces

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -44,15 +44,15 @@
   highlight = function(source, sections, callback) {
     var language, output, pygments, section;
     language = get_language(source);
-    pygments = spawn('pygmentize', ['-l', language.name, '-f', 'html', '-O', 'encoding=utf-8']);
+    pygments = spawn('pygmentize', ['-l', language.name, '-f', 'html', '-O', 'encoding=utf-8,tabsize=2']);
     output = '';
     pygments.stderr.addListener('data', function(error) {
       if (error) {
-        return console.error(error);
+        return console.error(error.toString());
       }
     });
     pygments.stdin.addListener('error', function(error) {
-      console.error("Error trying to run pygmentized to highlight the source. Do you have it installed?");
+      console.error("Could not use Pygments to highlight the source.");
       return process.exit(1);
     });
     pygments.stdout.addListener('data', function(result) {

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -101,7 +101,7 @@ parse = (source, code) ->
 # wherever our markers occur.
 highlight = (source, sections, callback) ->
   language = get_language source
-  pygments = spawn 'pygmentize', ['-l', language.name, '-f', 'html', '-O', 'encoding=utf-8']
+  pygments = spawn 'pygmentize', ['-l', language.name, '-f', 'html', '-O', 'encoding=utf-8,tabsize=2']
   output   = ''
   
   pygments.stderr.addListener 'data',  (error)  ->


### PR DESCRIPTION
Change the number of spaces pygments will use in place of tabs to 2 instead of the eye busting default of 8.
