### PR TITLE
Don't overwrite docco.css if it exists.

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -149,7 +149,11 @@
   if (sources.length) {
     ensure_directory('docs', function() {
       var files, next_file;
-      fs.writeFile('docs/docco.css', docco_styles);
+      path.exists('docs/docco.css', function(exists) {
+        if (!exists) {
+          return fs.writeFile('docs/docco.css', docco_styles);
+        }
+      });
       files = sources.slice(0);
       next_file = function() {
         if (files.length) {

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -226,7 +226,9 @@ highlight_end   = '</pre></div>'
 sources = process.ARGV.sort()
 if sources.length
   ensure_directory 'docs', ->
-    fs.writeFile 'docs/docco.css', docco_styles
+    path.exists 'docs/docco.css', (exists) ->
+        if not exists
+            fs.writeFile 'docs/docco.css', docco_styles
     files = sources.slice(0)
     next_file = -> generate_documentation files.shift(), next_file if files.length
     next_file()


### PR DESCRIPTION
Often users want to customize the CSS file. If docco won't overwrite
it, then it's possible to add one's own version to a repository,
and keep generating docs using the same CSS for rendering.
