### PR TITLE
Added --watch

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -3,7 +3,7 @@
 option '-p', '--prefix [DIR]', 'set the installation prefix for `cake install`'
 option '-w', '--watch', 'continually build the docco library'
 
-task 'build', 'continually build the docco library with --watch', (options) ->
+task 'build', 'build the docco library', (options) ->
   coffee = spawn 'coffee', ['-c' + (if options.watch then 'w' else ''), '-o', 'lib', 'src']
   coffee.stdout.on 'data', (data) -> console.log data.toString().trim()
 


### PR DESCRIPTION
The build task in the Cakefile passes '-w' to Node by default, however, the description mentions a '--watch' option which was not present.

This commit adds the '--watch' option.
