### PR TITLE
Support for mult-iline/here comments in JavaScript

### DIFF
--- a/README
+++ b/README
@@ -11,3 +11,17 @@ Docco is a quick-and-dirty, hundred-line-long, literate-programming-style
 documentation generator. For more information, see:
 
 http://jashkenas.github.com/docco/
+
+===================================================================
+
+This fork supports JSDoc style comments and highlights declared parameters.
+
+Example:
+
+/**
+ * @description Lolify someone's name
+ * @param {String} name A person's name
+ */
+function lolify(name) {
+   return 'OH HAI ' + name + ' KTHXBAI';
+}

--- a/lib/docco.js
+++ b/lib/docco.js
@@ -14,7 +14,8 @@
   };
 
   parse = function(source, code) {
-    var code_text, docs_text, has_code, incomment, language, line, lines, save, sections, _i, _len;
+    var code_text, docs_text, has_code, incomment, language, line, lines, param, save, sections, _i, _len;
+    param = '';
     lines = code.split('\n');
     sections = [];
     language = get_language(source);
@@ -38,6 +39,9 @@
         line = line.replace(language.comment_exit, '');
         line = line.replace(language.comment_enter, '');
         line = line.replace(language.comment_matcher, '');
+        line = line.replace(/^ +/, '');
+        param = line.match(language.param);
+        if (param) line = line.replace(param[0], '\n' + '<b>' + param[1] + '</b>');
         docs_text += line + '\n';
       } else {
         has_code = true;
@@ -120,7 +124,8 @@
       name: 'javascript',
       symbol: '//',
       enter: '/\\*\+',
-      exit: '\\*\+/'
+      exit: '\\*\+/',
+      param: /\* *@([a-zA-Z]+)/
     },
     '.rb': {
       name: 'ruby',

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -75,6 +75,7 @@ generate_documentation = (source, callback) ->
 #     }
 #
 parse = (source, code) ->
+  param    = ''
   lines    = code.split '\n'
   sections = []
   language = get_language source
@@ -96,6 +97,10 @@ parse = (source, code) ->
       line = line.replace(language.comment_exit, '')
       line = line.replace(language.comment_enter, '')
       line = line.replace(language.comment_matcher, '')
+      line = line.replace(/^ +/, '');
+      param = line.match(language.param);
+      if param
+        line = line.replace(param[0], '\n' + '<b>' + param[1] + '</b>');
       docs_text += line + '\n'
     else
       has_code = yes
@@ -165,7 +170,7 @@ languages =
   '.coffee':
     name: 'coffee-script', symbol: '#'
   '.js':
-    name: 'javascript', symbol: '//', enter: '/\\*\+', exit: '\\*\+/'
+    name: 'javascript', symbol: '//', enter: '/\\*\+', exit: '\\*\+/', param: /\* *@([a-zA-Z]+)/
   '.rb':
     name: 'ruby', symbol: '#'
   '.py':


### PR DESCRIPTION
docco now parses block comments in JavaScript code.   This allows you to use natural docs style commenting but still generate docco html.  Example:

https://gist.github.com/1440633
