### PR TITLE
Add support for [La]TeX

### DIFF
--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -166,8 +166,6 @@ languages =
     name: 'tex', symbol: '%'
   '.latex':
     name: 'tex', symbol: '%'
-  '.sty':
-    name: 'tex', symbol: '%'
 
 # Build out the appropriate matchers and delimiters for each language.
 for ext, l of languages


### PR DESCRIPTION
Adds support for TeX files (_.tex), LaTeX files (_.latex), and TeX styles (*.sty).
These work out of the box as [La]TeX is a supported language in Pygments.
