### PR TITLE
Skip unrecognized sources for easier batch processing

### DIFF
--- a/bin/docco
+++ b/bin/docco
@@ -5,4 +5,17 @@ var fs = require('fs');
 var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
 process.ARGV = process.argv = process.argv.slice(2, process.argv.length);
+
+process.OPTS = {};
+
+// -c, --css   specify stylesheet link, default to 'docco.css'
+var pos = process.ARGV.indexOf('-c');
+if(pos == -1) pos = process.ARGV.indexOf('--css');
+if(pos != -1) process.OPTS.css = process.ARGV.splice(pos, 2)[1];
+
+// -o, --out   specify output location, default to 'docs'
+pos = process.ARGV.indexOf('-o');
+if(pos == -1) pos = process.ARGV.indexOf('--out');
+if(pos != -1) process.OPTS.out = process.ARGV.splice(pos, 2)[1];
+
 require(lib + '/docco.js');

--- a/resources/docco.jst
+++ b/resources/docco.jst
@@ -5,7 +5,7 @@
   <title><%= title %></title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="generator" content="Docco">
-  <link rel="stylesheet" media="all" href="docco.css" />
+  <link rel="stylesheet" media="all" href="<%= opts.css || 'docco.css' %>" />
 </head>
 <body>
   <div id="container">

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -136,7 +136,7 @@ generate_html = (source, sections) ->
   title = path.basename source
   dest  = destination source
   html  = docco_template {
-    title: title, sections: sections, sources: sources, path: path, destination: destination
+    title: title, sections: sections, sources: sources, path: path, destination: destination, opts: process.OPTS
   }
   console.log "docco: #{source} -> #{dest}"
   fs.writeFile dest, html
@@ -196,7 +196,7 @@ get_language = (source) -> languages[path.extname(source)]
 # Compute the destination HTML path for an input source file path. If the source
 # is `lib/example.coffee`, the HTML will be at `docs/example.html`
 destination = (filepath) ->
-  'docs/' + path.basename(filepath, path.extname(filepath)) + '.html'
+  (process.OPTS.out ? 'docs') + '/' + path.basename(filepath, path.extname(filepath)) + '.html'
 
 # Ensure that the destination directory exists.
 ensure_directory = (dir, callback) ->
@@ -233,8 +233,8 @@ highlight_end   = '</pre></div>'
 # For each recognized source file passed in as an argument, generate the documentation. Log sources of unknown types.
 sources = process.ARGV.filter((source) -> (get_language source) ? console.log "Unknown Type: #{source}").sort()
 if sources.length
-  ensure_directory 'docs', ->
-    fs.writeFile 'docs/docco.css', docco_styles
+  ensure_directory process.OPTS.out ? 'docs', ->
+    fs.writeFile (process.OPTS.out ? 'docs') + '/docco.css', docco_styles if !process.OPTS.css
     files = sources.slice(0)
     next_file = -> generate_documentation files.shift(), next_file if files.length
     next_file()


### PR DESCRIPTION
Hi Jeremy,

I've made a one-line modification to docco.coffee.

The modification skips unrecognized sources (and provide friendly information), make below command possible:

`docco src/*`

Outputs:

```
Unknown Type: src/source_of_unknown_extension.xyz
docco: src/docco.coffee -> docs/docco.html
```

W/o the modification, above command will throw an exception.

Filter the sources in the command line is not a good option when we simply wanna document all sources of recognized types.

Please advise :)
