### PR TITLE
Minor tweaks for easier batch processing

### DIFF
--- a/bin/docco
+++ b/bin/docco
@@ -5,4 +5,17 @@ var fs = require('fs');
 var lib = path.join(path.dirname(fs.realpathSync(__filename)), '../lib');
 
 process.ARGV = process.argv = process.argv.slice(2, process.argv.length);
+
+process.OPTS = {};
+
+// -c, --css   specify stylesheet link, default to 'docco.css'
+var pos = process.ARGV.indexOf('-c');
+if(pos == -1) pos = process.ARGV.indexOf('--css');
+if(pos != -1) process.OPTS.css = process.ARGV.splice(pos, 2)[1];
+
+// -o, --out   specify output location, default to 'docs'
+pos = process.ARGV.indexOf('-o');
+if(pos == -1) pos = process.ARGV.indexOf('--out');
+if(pos != -1) process.OPTS.out = process.ARGV.splice(pos, 2)[1];
+
 require(lib + '/docco.js');

--- a/resources/docco.jst
+++ b/resources/docco.jst
@@ -5,7 +5,7 @@
   <title><%= title %></title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta name="generator" content="Docco">
-  <link rel="stylesheet" media="all" href="docco.css" />
+  <link rel="stylesheet" media="all" href="<%= opts.css || 'docco.css' %>" />
 </head>
 <body>
   <div id="container">

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -136,7 +136,7 @@ generate_html = (source, sections) ->
   title = path.basename source
   dest  = destination source
   html  = docco_template {
-    title: title, sections: sections, sources: sources, path: path, destination: destination
+    title: title, sections: sections, sources: sources, path: path, destination: destination, opts: process.OPTS
   }
   console.log "docco: #{source} -> #{dest}"
   fs.writeFile dest, html
@@ -196,7 +196,7 @@ get_language = (source) -> languages[path.extname(source)]
 # Compute the destination HTML path for an input source file path. If the source
 # is `lib/example.coffee`, the HTML will be at `docs/example.html`
 destination = (filepath) ->
-  'docs/' + path.basename(filepath, path.extname(filepath)) + '.html'
+  destdir + '/' + path.basename(filepath, path.extname(filepath)) + '.html'
 
 # Ensure that the destination directory exists.
 ensure_directory = (dir, callback) ->
@@ -232,9 +232,10 @@ highlight_end   = '</pre></div>'
 # Run the script.
 # For each recognized source file passed in as an argument, generate the documentation. Log sources of unknown types.
 sources = process.ARGV.filter((source) -> (get_language source) ? console.log "Unknown Type: #{source}").sort()
+destdir = process.OPTS.out ? 'docs'
 if sources.length
-  ensure_directory 'docs', ->
-    fs.writeFile 'docs/docco.css', docco_styles
+  ensure_directory destdir, ->
+    fs.writeFile destdir + '/docco.css', docco_styles if !process.OPTS.css
     files = sources.slice(0)
     next_file = -> generate_documentation files.shift(), next_file if files.length
     next_file()


### PR DESCRIPTION
Three minor modifications have been made to docco to:
1. Make batch processing easier. Repository-wide document generation and automated syncing between sources & documents become possible.
2. Make docco's original usage scenarios more friendly. Provide feedback when encountering unrecognized extension. Provide the most demanded options (custom stylesheet link and output directory).

There're three commits included in this pull request:
1. Provide user friendly information when encountering unrecognized extension.
2. Embed a meta tag in the template serving as a signature of files generated by docco.
3. Provide -c (--css) option to overwrite stylesheet link, and -o (--out) option to overwrite 'doc' folder.

All the modifications didn't introduce a new line to docco.coffee. And only add a meta tag to the template.

Usage:

```
docco src/*
```

will provide warning on unrecognized files:

```
Unknown Type: src/source_of_unknown_extension.xyz
docco: src/docco.coffee -> docs/docco.html
```

And:

```
docco --css 'http://static.yourdomain.com/stylesheets/docco.css' src/*
```

will use the specified css file in the generated html file.

And:

```
find . -type f -exec grep -l -i '<meta name="generator" content="docco.*">' '{}' ';'
```

can find the files generated by docco.

Please have a review.
