### PR TITLE
Adding basic usage of docco command

### DIFF
--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -232,7 +232,9 @@ highlight_end   = '</pre></div>'
 # Run the script.
 # For each source file passed in as an argument, generate the documentation.
 sources = process.ARGV.sort()
-if sources.length
+if !sources.length || sources[0] == '-h' || sources[0] == '--help'
+  process.stdout.write("Usage: docco <directory to process>\r\n")
+else
   ensure_directory 'docs', ->
     fs.writeFile 'docs/docco.css', docco_styles
     files = sources.slice(0)


### PR DESCRIPTION
This should be a better way of handling when no arguments are provided, or when someone calls `-h`/`--help`, which are the de facto "I don't know what I'm doing here" arguments.
