### PR TITLE
Moving language support to an external JSON formatted file.

### DIFF
--- a/lib/docco.js
+++ b/lib/docco.js
@@ -102,24 +102,7 @@
   path = require('path');
   showdown = require('./../vendor/showdown').Showdown;
   _ref = require('child_process'), spawn = _ref.spawn, exec = _ref.exec;
-  languages = {
-    '.coffee': {
-      name: 'coffee-script',
-      symbol: '#'
-    },
-    '.js': {
-      name: 'javascript',
-      symbol: '//'
-    },
-    '.rb': {
-      name: 'ruby',
-      symbol: '#'
-    },
-    '.py': {
-      name: 'python',
-      symbol: '#'
-    }
-  };
+  languages = JSON.parse(fs.readFileSync(__dirname + "/../resources/languages.json").toString());
   for (ext in languages) {
     l = languages[ext];
     l.comment_matcher = new RegExp('^\\s*' + l.symbol + '\\s?');

--- a/resources/languages.json
+++ b/resources/languages.json
@@ -1,0 +1,27 @@
+{ ".coffee" :
+    {"name" : "coffee-script", "symbol" : "#"},
+  ".rb":
+    {"name" : "ruby", "symbol" : "#"},
+  ".py":
+    {"name": "python", "symbol" : "#"},
+  ".feature":
+    {"name" : "gherkin", "symbol" : "#"},
+  ".yaml":
+    {"name" : "yaml", "symbol" : "#"},
+  ".tex":
+    {"name" : "tex", "symbol" : "%"},
+  ".latex":
+    {"name" : "tex", "symbol" : "%"},
+  ".js":
+    {"name" : "javascript", "symbol" : "//"},
+  ".c":
+    {"name" : "c", "symbol" : "//"},
+  ".h":
+    {"name" : "c", "symbol" : "//"},
+  ".cpp":
+    {"name" : "cpp", "symbol" : "//"},
+  ".php":
+    {"name" : "php", "symbol" : "//"},
+  ".hs":
+    {"name" : "haskell", "symbol" : "--"}
+}

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -150,26 +150,10 @@ path     = require 'path'
 showdown = require('./../vendor/showdown').Showdown
 {spawn, exec} = require 'child_process'
 
-# A list of the languages that Docco supports, mapping the file extension to
-# the name of the Pygments lexer and the symbol that indicates a comment. To
-# add another language to Docco's repertoire, add it here.
-languages =
-  '.coffee':
-    name: 'coffee-script', symbol: '#'
-  '.js':
-    name: 'javascript', symbol: '//'
-  '.rb':
-    name: 'ruby', symbol: '#'
-  '.py':
-    name: 'python', symbol: '#'
-  '.tex':
-    name: 'tex', symbol: '%'
-  '.latex':
-    name: 'tex', symbol: '%'
-  '.c':
-    name: 'c', symbol: '//'
-  '.h':
-    name: 'c', symbol: '//'
+# Languages are stored in JSON format in the file `resources/languages.json`
+# Each item maps the file extension to the name of the Pygments lexer and the
+# symbol that indicates a comment. To add a new language, modify the file.
+languages = JSON.parse fs.readFileSync(__dirname + "/../resources/languages.json").toString()
 
 # Build out the appropriate matchers and delimiters for each language.
 for ext, l of languages


### PR DESCRIPTION
This should cut down on the noisiness of the patches for new language support and
also keep the static data out of the source code, since it will only grow.

Also, I added support for the languages in the existing pull request queue, please check syntax if your pull request is affected: 
- Pull Request 94 for C++ support
- Pull Request 90 for YAML support
- Pull Request 40 & 36 PHP support
- Pull Request 33 Haskell support

I added the languages based on comment selector character, I guess that is as good as any from an organizational standpoint. I would be open to other sorting though.
