### PR TITLE
Improve CSS for back-ticked code

### DIFF
--- a/resources/docco.css
+++ b/resources/docco.css
@@ -84,7 +84,7 @@ table td {
       margin: 15px 0 15px;
       padding-left: 15px;
     }
-    .docs p tt, .docs p code {
+    .docs p tt, .docs p code, .docs li code {
       background: #f8f8ff;
       border: 1px solid #dedede;
       font-size: 12px;


### PR DESCRIPTION
Back-ticked code in <li> (eg \* `x = 1`) isn't displayed like other <code> elements.
