### PR TITLE
improve colors for numbers, operators and functions

### DIFF
--- a/resources/docco.css
+++ b/resources/docco.css
@@ -133,7 +133,7 @@ body .hll { background-color: #ffffcc }
 body .c { color: #408080; font-style: italic }  /* Comment */
 body .err { border: 1px solid #FF0000 }         /* Error */
 body .k { color: #954121 }                      /* Keyword */
-body .o { color: #666666 }                      /* Operator */
+body .o { color: #954121 }                      /* Operator */
 body .cm { color: #408080; font-style: italic } /* Comment.Multiline */
 body .cp { color: #BC7A00 }                     /* Comment.Preproc */
 body .c1 { color: #408080; font-style: italic } /* Comment.Single */
@@ -154,26 +154,26 @@ body .kn { color: #954121; font-weight: bold }  /* Keyword.Namespace */
 body .kp { color: #954121 }                     /* Keyword.Pseudo */
 body .kr { color: #954121; font-weight: bold }  /* Keyword.Reserved */
 body .kt { color: #B00040 }                     /* Keyword.Type */
-body .m { color: #666666 }                      /* Literal.Number */
+body .m { color: #8055AF }                      /* Literal.Number */
 body .s { color: #219161 }                      /* Literal.String */
 body .na { color: #7D9029 }                     /* Name.Attribute */
 body .nb { color: #954121 }                     /* Name.Builtin */
-body .nc { color: #0000FF; font-weight: bold }  /* Name.Class */
+body .nc { color: #CA8A45; font-weight: bold }  /* Name.Class */
 body .no { color: #880000 }                     /* Name.Constant */
 body .nd { color: #AA22FF }                     /* Name.Decorator */
 body .ni { color: #999999; font-weight: bold }  /* Name.Entity */
 body .ne { color: #D2413A; font-weight: bold }  /* Name.Exception */
-body .nf { color: #0000FF }                     /* Name.Function */
+body .nf { color: #CA8A45 }                     /* Name.Function */
 body .nl { color: #A0A000 }                     /* Name.Label */
-body .nn { color: #0000FF; font-weight: bold }  /* Name.Namespace */
+body .nn { color: #CA8A45; font-weight: bold }  /* Name.Namespace */
 body .nt { color: #954121; font-weight: bold }  /* Name.Tag */
 body .nv { color: #19469D }                     /* Name.Variable */
 body .ow { color: #AA22FF; font-weight: bold }  /* Operator.Word */
 body .w { color: #bbbbbb }                      /* Text.Whitespace */
-body .mf { color: #666666 }                     /* Literal.Number.Float */
-body .mh { color: #666666 }                     /* Literal.Number.Hex */
-body .mi { color: #666666 }                     /* Literal.Number.Integer */
-body .mo { color: #666666 }                     /* Literal.Number.Oct */
+body .mf { color: #8055AF }                     /* Literal.Number.Float */
+body .mh { color: #8055AF }                     /* Literal.Number.Hex */
+body .mi { color: #8055AF }                     /* Literal.Number.Integer */
+body .mo { color: #8055AF }                     /* Literal.Number.Oct */
 body .sb { color: #219161 }                     /* Literal.String.Backtick */
 body .sc { color: #219161 }                     /* Literal.String.Char */
 body .sd { color: #219161; font-style: italic } /* Literal.String.Doc */
@@ -189,4 +189,4 @@ body .bp { color: #954121 }                     /* Name.Builtin.Pseudo */
 body .vc { color: #19469D }                     /* Name.Variable.Class */
 body .vg { color: #19469D }                     /* Name.Variable.Global */
 body .vi { color: #19469D }                     /* Name.Variable.Instance */
-body .il { color: #666666 }                     /* Literal.Number.Integer.Long */
+body .il { color: #8055AF }                     /* Literal.Number.Integer.Long */


### PR DESCRIPTION
not sure if the current colors were chosen for specific reasons, but i think a few could be improved. particularly the bright blue has aways been a bit jarring.

here's a before and after shot:

![Before and After](http://cl.ly/image/1d1y2g0L002f/docco.png)
http://cl.ly/image/1d1y2g0L002f

**numbers** gray -> muted purple
**functions** bright blue -> muted orange
**operators** gray -> the same deep red as **keywords**

they fit in a bit better.
