### PR TITLE
Support Continuous Integration Build Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.8
+  - 0.6

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "main" :        "./lib/docco",
   "bin": {
     "docco":      "./bin/docco"
+  },
+  "scripts" : {
+    "test":       "cake test"
   }
 }


### PR DESCRIPTION
**The Problem**
As a contributor to Docco, I would like to be able to prove that the tests I write pass, and the code I contribute does not introduce errors into the existing test-suite.  I would like this to be evidenced in my pull requests, so that a reviewer can easily sanity check my contributions.

**The Solution**
Add a `.travis.yml` configuration file, and an `npm test` script update to package.json.  Any fork may choose to enable Travis-CI for their repository (which is a free service for open source projects), and may benefit from the comfort of knowing that their changes do not break existing functionality in Docco that is tested.

**Testing**
When Travis-CI is enabled for a fork, each push will be tested, and failed builds will be reported via email.  When Travis-CI is not enabled, these changes still have the benefit of enabling `npm test` support.
