### PR TITLE
Use at least CoffeeScript 1.3.3 for CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "commander": ">=0.5.2"
   },
   "devDependencies": {
-    "coffee-script": "1.1.3",
+    "coffee-script": ">=1.3.3",
     "rimraf"       :">=2.0.2"
   },
   "main" :        "./lib/docco",


### PR DESCRIPTION
Using CoffeeScript 1.1.3 produces a 'pure statement' error in `docco.coffee`
