### PR TITLE
Resolve issue addressed by pull request #101

### DIFF
--- a/resources/docco.css
+++ b/resources/docco.css
@@ -156,7 +156,7 @@ ul.sections > li > div {
     padding-left: 15px;
   }
 
-  ul.sections > li > div.annotation p tt, .annotation p code {
+  ul.sections > li > div.annotation p tt, .annotation code {
     background: #f8f8ff;
     border: 1px solid #dedede;
     font-size: 12px;


### PR DESCRIPTION
The style for backtick (code) elements was only being applied to annotation `<li>` elements that had their code wrapped in a `<p>`.  

This is not the case for single-line `<li>` annotation blocks.  Apply the style to any code child of an annotation element.
