### PR TITLE
Adding support for --force-ext option.

### DIFF
--- a/README
+++ b/README
@@ -21,6 +21,7 @@ Usage: docco [options] <filePattern ...>
     -c, --css [file]       use a custom css file
     -o, --output [path]    use a custom output path
     -t, --template [file]  use a custom .jst template
+    --force-ext <ext>      treat the target files as if they have a specific extension
 
 Building and Testing:
 

--- a/lib/docco.js
+++ b/lib/docco.js
@@ -10,22 +10,21 @@
         throw error;
       }
       code = buffer.toString();
-      sections = parse(source, code);
-      return highlight(source, sections, function() {
+      sections = parse(source, code, config);
+      return highlight(source, sections, config, function() {
         generateHtml(source, sections, config);
         return callback();
       });
     });
   };
 
-  parse = function(source, code) {
+  parse = function(source, code, config) {
     var codeText, docsText, hasCode, language, line, lines, save, sections, _i, _len;
     lines = code.split('\n');
     sections = [];
-    language = getLanguage(source);
+    language = getLanguage(source, config);
     hasCode = docsText = codeText = '';
     save = function(docsText, codeText) {
-      console.log(docsText);
       return sections.push({
         docsText: docsText,
         codeText: codeText
@@ -48,9 +47,9 @@
     return sections;
   };
 
-  highlight = function(source, sections, callback) {
+  highlight = function(source, sections, config, callback) {
     var code, docs, language, output, pygments, section;
-    language = getLanguage(source);
+    language = getLanguage(source, config);
     pygments = spawn('pygmentize', ['-l', language.name, '-f', 'html', '-O', 'encoding=utf-8,tabsize=2']);
     output = '';
     code = ((function() {
@@ -159,8 +158,12 @@
     l.docsSplitHtml = RegExp("<h1>" + l.name + "DOCDIVIDER</h1>");
   }
 
-  getLanguage = function(source) {
-    return languages[path.extname(source)];
+  getLanguage = function(source, config) {
+    if ((config != null ? config.forceExt : void 0) != null) {
+      return languages[config.forceExt];
+    } else {
+      return languages[path.extname(source)];
+    }
   };
 
   ensureDirectory = function(dir, cb, made) {
@@ -199,14 +202,15 @@
   defaults = {
     template: "" + __dirname + "/../resources/docco.jst",
     css: "" + __dirname + "/../resources/docco.css",
-    output: "docs/"
+    output: "docs/",
+    forceExt: null
   };
 
   run = function(args) {
     if (args == null) {
       args = process.argv;
     }
-    commander.version(version).usage("[options] <filePattern ...>").option("-c, --css [file]", "use a custom css file", defaults.css).option("-o, --output [path]", "use a custom output path", defaults.output).option("-t, --template [file]", "use a custom .jst template", defaults.template).parse(args).name = "docco";
+    commander.version(version).usage("[options] <filePattern ...>").option("-c, --css [file]", "use a custom css file", defaults.css).option("-o, --output [path]", "use a custom output path", defaults.output).option("-t, --template [file]", "use a custom .jst template", defaults.template).option("--force-ext <ext>", "treat the target files as if they have a specific extension", defaults.forceExt).parse(args).name = "docco";
     if (commander.args.length) {
       return document(commander.args.slice(), commander);
     } else {
@@ -239,7 +243,7 @@
       resolved = resolved.concat(resolveSource(src));
     }
     config.sources = resolved.filter(function(source) {
-      return getLanguage(source);
+      return getLanguage(source, config);
     }).sort();
     for (_j = 0, _len1 = resolved.length; _j < _len1; _j++) {
       m = resolved[_j];

--- a/src/docco.coffee
+++ b/src/docco.coffee
@@ -60,8 +60,8 @@ generateDocumentation = (source, config, callback) ->
   fs.readFile source, (error, buffer) ->
     throw error if error
     code = buffer.toString()
-    sections = parse source, code
-    highlight source, sections, ->
+    sections = parse source, code, config
+    highlight source, sections, config, ->
       generateHtml source, sections, config
       callback()
 
@@ -76,10 +76,10 @@ generateDocumentation = (source, config, callback) ->
 #       codeHtml: ...
 #     }
 #
-parse = (source, code) ->
+parse = (source, code, config) ->
   lines    = code.split '\n'
   sections = []
-  language = getLanguage source
+  language = getLanguage source, config
   hasCode  = docsText = codeText = ''
 
   save = (docsText, codeText) ->
@@ -106,8 +106,8 @@ parse = (source, code) ->
 # We process all sections with single calls to Pygments and Showdown, by 
 # inserting marker comments between them, and then splitting the result
 # string wherever the marker occurs.
-highlight = (source, sections, callback) ->
-  language = getLanguage source
+highlight = (source, sections, config, callback) ->
+  language = getLanguage source, config
   pygments = spawn 'pygmentize', [
     '-l', language.name,
     '-f', 'html',
@@ -216,7 +216,11 @@ for ext, l of languages
   l.docsSplitHtml = ///<h1>#{l.name}DOCDIVIDER</h1>///
 
 # Get the current language we're documenting, based on the extension.
-getLanguage = (source) -> languages[path.extname(source)]
+getLanguage = (source, config) ->
+  if config?.forceExt?
+    languages[config.forceExt]
+  else
+    languages[path.extname(source)]
 
 # Ensure that the destination directory exists.
 ensureDirectory = (dir, cb, made=null) ->
@@ -257,6 +261,7 @@ defaults =
   template: "#{__dirname}/../resources/docco.jst"
   css     : "#{__dirname}/../resources/docco.css"
   output  : "docs/"
+  forceExt: null
 
 
 # ### Run from Commandline
@@ -271,6 +276,7 @@ run = (args=process.argv) ->
     .option("-c, --css [file]","use a custom css file",defaults.css)
     .option("-o, --output [path]","use a custom output path",defaults.output)
     .option("-t, --template [file]","use a custom .jst template",defaults.template)
+    .option("--force-ext <ext>","treat the target files as if they have a specific extension",defaults.forceExt)
     .parse(args)
     .name = "docco"
   if commander.args.length
@@ -294,7 +300,7 @@ document = (sources, options = {}, callback = null) ->
 
   resolved = []
   resolved = resolved.concat(resolveSource(src)) for src in sources
-  config.sources = resolved.filter((source) -> getLanguage source).sort()
+  config.sources = resolved.filter((source) -> getLanguage source, config).sort()
   console.log "docco: skipped unknown type (#{m})" for m in resolved when m not in config.sources  
   
   config.doccoTemplate = template fs.readFileSync(config.template).toString()

--- a/test/comments/noextension
+++ b/test/comments/noextension
@@ -1,0 +1,2 @@
+# With no extension, the only way this can be correctly processed is by specifying `--force-ext .coffee`. 
+console.log "I'm really coffeescript!"

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -36,6 +36,12 @@ test "custom CSS file", ->
     ["#{testPath}/*.coffee"],
     css: "#{resourcesPath}/pagelet.css"
 
+# **Specifying a filetype independent of extension should be supported** 
+test "specify an extension", ->
+  testDoccoRun "specify_extension",
+    ["#{testPath}/comments/noextension"],
+    forceExt: ".coffee"
+
 # **Comments should be parsed properly**
 #  
 # There are special data files located in `test/comments` for each supported 


### PR DESCRIPTION
Allows the user to specify an extension on the commandline. When present, all input files will be processed as if they have this extension.

This is useful if you have filenames with multiple sequential extensions, or just a non-standard extension that cannot be changed for one reason or another.

For example, I have quite a few files which have `.coffee.erb` extensions. These files are 99.9% Coffeescript and can be parsed as such, but having the `.erb` suffix is required for our rendering engine. With this change, I can process them like so:

```
docco --force-ext .coffee path/*.coffee.erb
```
