### PR TITLE
Adds scala support

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -41,5 +41,7 @@
   ".less":
     {"name" : "scss", "symbol": "//"},
   ".m":
-    {"name" : "objc", "symbol": "//"}
+    {"name" : "objc", "symbol": "//"},
+  ".scala":
+    {"name" : "scala", "symbol": "//"}
 }

--- a/test/comments/scala.scala
+++ b/test/comments/scala.scala
@@ -1,0 +1,11 @@
+// 1
+
+def foo {
+   val bar = "heynow"
+}
+
+/**
+  * These comments are meaningful too
+  */
+def commentAbove(param : String) {
+}


### PR DESCRIPTION
I've added support for scala to docco.  There is already a scala port of docco (found here: https://github.com/philcali/sbt-cx-docco), but it doesn't build nor is it usable in a scala project that I am trying to generate docs for.  This simple fix lets me use docco for scala.  Would you mind accepting it?
