### PR TITLE
Export configure

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -195,6 +195,7 @@
     run: run,
     document: document,
     parse: parse,
+    configure: configure,
     version: version
   };
 

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -281,4 +281,4 @@ Parse options using [Commander](https://github.com/visionmedia/commander.js).
 Public API
 ----------
 
-    Docco = module.exports = {run, document, parse, version}
+    Docco = module.exports = {run, document, parse, configure, version}

--- a/index.html
+++ b/index.html
@@ -31,9 +31,7 @@ code. All prose is passed through
 <a href="http://daringfireball.net/projects/markdown/syntax">Markdown</a>, and code is
 passed through <a href="http://highlightjs.org/">Highlight.js</a> syntax highlighting.
 This page is the result of running Docco against its own
-<a href="https://github.com/jashkenas/docco/blob/master/docco.litcoffee">source file</a>.
-
-</p>
+<a href="https://github.com/jashkenas/docco/blob/master/docco.litcoffee">source file</a>.</p>
 <ol>
 <li><p>Install Docco with <strong>npm</strong>: <code>sudo npm install -g docco</code></p>
 </li>
@@ -42,22 +40,15 @@ This page is the result of running Docco against its own
 </ol>
 <p>There is no &quot;Step 3&quot;. This will generate an HTML page for each of the named
 source files, with a menu linking to the other pages, saving the whole mess
-into a <code>docs</code> folder (configurable).
-
-</p>
+into a <code>docs</code> folder (configurable).</p>
 <p>The <a href="http://github.com/jashkenas/docco">Docco source</a> is available on GitHub,
-and is released under the <a href="http://opensource.org/licenses/MIT">MIT license</a>.
-
-</p>
+and is released under the <a href="http://opensource.org/licenses/MIT">MIT license</a>.</p>
 <p>Docco can be used to process code written in any programming language. If it
 doesn&#39;t handle your favorite yet, feel free to
 <a href="https://github.com/jashkenas/docco/blob/master/resources/languages.json">add it to the list</a>.
 Finally, the <a href="http://coffeescript.org/#literate">&quot;literate&quot; style</a> of <em>any</em>
 language is also supported — just tack an <code>.md</code> extension on the end:
-<code>.coffee.md</code>, <code>.py.md</code>, and so on.
-
-
-</p>
+<code>.coffee.md</code>, <code>.py.md</code>, and so on.</p>
 <h2>Partners in Crime:</h2>
 
         
@@ -92,13 +83,10 @@ aficionado, check out <a href="https://github.com/dontangg">Don Wilson</a>&#39;s
 </li>
 <li><p>Going further afield from the quick-and-dirty, <a href="http://nevir.github.com/groc/">Groc</a>
 is a <strong>CoffeeScript</strong> fork of Docco that adds a searchable table of contents,
-and aims to gracefully handle large projects with complex heirarchies of code.</p>
+and aims to gracefully handle large projects with complex hierarchies of code.</p>
 </li>
 </ul>
-<p>Note that not all ports will support all Docco features ... yet.
-
-
-</p>
+<p>Note that not all ports will support all Docco features ... yet.</p>
 <h2>Main Documentation Generation Functions</h2>
 
         
@@ -107,9 +95,7 @@ and aims to gracefully handle large projects with complex heirarchies of code.</
         <p>Generate the documentation for our configured source file by copying over static
 assets, reading all the source files in, splitting them up into prose+code
 sections, highlighting each file in the appropriate language, and printing them
-out in an HTML template.
-
-</p>
+out in an HTML template.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">document</span></span> = -&gt;
@@ -137,9 +123,7 @@ out in an HTML template.
         <p>Given a string of source code, <strong>parse</strong> out each block of prose and the code that
 follows it — by detecting which is which, line by line — and then create an
 individual <strong>section</strong> for it. Each section is an object with <code>docsText</code> and
-<code>codeText</code> properties, and eventually <code>docsHtml</code> and <code>codeHtml</code> as well.
-
-</p>
+<code>codeText</code> properties, and eventually <code>docsHtml</code> and <code>codeHtml</code> as well.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">parse</span></span> = (source, code) -&gt;
@@ -156,9 +140,7 @@ individual <strong>section</strong> for it. Each section is an object with <code
         
         <p>Our quick-and-dirty implementation of the literate programming style. Simply
 invert the prose and code relationship on a per-line basis, and then continue as
-normal below.
-
-</p>
+normal below.</p>
 
         
           <div class='highlight'><pre><span class="keyword">if</span> lang.literate
@@ -189,9 +171,7 @@ normal below.
         
         <p>To <strong>format</strong> and highlight the now-parsed sections of code, we use <strong>Highlight.js</strong>
 over stdio, and run the text of their corresponding comments through
-<strong>Markdown</strong>, using <a href="https://github.com/chjj/marked">Marked</a>.
-
-</p>
+<strong>Markdown</strong>, using <a href="https://github.com/chjj/marked">Marked</a>.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">format</span></span> = (source, sections) -&gt;
@@ -205,9 +185,7 @@ over stdio, and run the text of their corresponding comments through
         
         <p>Once all of the code has finished highlighting, we can <strong>write</strong> the resulting
 documentation file by passing the completed HTML sections into the template,
-and rendering it to the specified output path.
-
-</p>
+and rendering it to the specified output path.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">write</span></span> = (source, sections) -&gt;
@@ -218,9 +196,7 @@ and rendering it to the specified output path.
       
         
         <p>The <strong>title</strong> of the file is either the first heading in the prose, or the
-name of the source file.
-
-</p>
+name of the source file.</p>
 
         
           <div class='highlight'><pre>first = marked.lexer(sections[<span class="number">0</span>].docsText)[<span class="number">0</span>]
@@ -241,9 +217,7 @@ name of the source file.
       
         
         <p>Default configuration <strong>options</strong>. All of these may be overriden by command-line
-options.
-
-</p>
+options.</p>
 
         
           <div class='highlight'><pre>config =
@@ -257,9 +231,7 @@ options.
         
         <p><strong>Configure</strong> this particular run of Docco. We might use a passed-in external
 template, or one of the built-in <strong>layouts</strong>. We only attempt to process
-source files for languages for which we have definitions.
-
-</p>
+source files for languages for which we have definitions.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">configure</span></span> = (options) -&gt;
@@ -287,9 +259,7 @@ source files for languages for which we have definitions.
         
       
         
-        <p>Require our external dependencies.
-
-</p>
+        <p>Require our external dependencies.</p>
 
         
           <div class='highlight'><pre>_             = require <span class="string">'underscore'</span>
@@ -305,36 +275,28 @@ commander     = require <span class="string">'commander'</span>
         <p>Languages are stored in JSON in the file <code>resources/languages.json</code>.
 Each item maps the file extension to the name of the language and the
 <code>symbol</code> that indicates a line comment. To add support for a new programming
-language to Docco, just add it to the file.
-
-</p>
+language to Docco, just add it to the file.</p>
 
         
           <div class='highlight'><pre>languages = JSON.parse fs.readFileSync(<span class="string">"<span class="subst">#{__dirname}</span>/resources/languages.json"</span>)</pre></div>
         
       
         
-        <p>Build out the appropriate matchers and delimiters for each language.
-
-</p>
+        <p>Build out the appropriate matchers and delimiters for each language.</p>
 
         
           <div class='highlight'><pre><span class="keyword">for</span> ext, l <span class="keyword">of</span> languages</pre></div>
         
       
         
-        <p>Does the line begin with a comment?
-
-</p>
+        <p>Does the line begin with a comment?</p>
 
         
           <div class='highlight'><pre>l.commentMatcher = <span class="regexp">///^\s*<span class="comment">#{l.symbol}\s?///</span></pre></div>
         
       
         
-        <p>Ignore <a href="http://en.wikipedia.org/wiki/Shebang_(Unix\">hashbangs</a>) and interpolations...
-
-</p>
+        <p>Ignore <a href="http://en.wikipedia.org/wiki/Shebang_(Unix\">hashbangs</a>) and interpolations...</p>
 
         
           <div class='highlight'><pre>l.commentFilter = <span class="regexp">/(^#![/]|^\s*#\{)/</span></pre></div>
@@ -342,9 +304,7 @@ language to Docco, just add it to the file.
       
         
         <p>A function to get the current language we&#39;re documenting, based on the
-file extension. Detect and tag &quot;literate&quot; <code>.ext.md</code> variants.
-
-</p>
+file extension. Detect and tag &quot;literate&quot; <code>.ext.md</code> variants.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">getLanguage</span></span> = (source) -&gt;
@@ -358,9 +318,7 @@ file extension. Detect and tag &quot;literate&quot; <code>.ext.md</code> variant
         
       
         
-        <p>Keep it DRY. Extract the docco <strong>version</strong> from <code>package.json</code>
-
-</p>
+        <p>Keep it DRY. Extract the docco <strong>version</strong> from <code>package.json</code></p>
 
         
           <div class='highlight'><pre>version = JSON.parse(fs.readFileSync(<span class="string">"<span class="subst">#{__dirname}</span>/package.json"</span>)).version</pre></div>
@@ -373,9 +331,7 @@ file extension. Detect and tag &quot;literate&quot; <code>.ext.md</code> variant
       
         
         <p>Finally, let&#39;s define the interface to run Docco from the command line.
-Parse options using <a href="https://github.com/visionmedia/commander.js">Commander</a>.
-
-</p>
+Parse options using <a href="https://github.com/visionmedia/commander.js">Commander</a>.</p>
 
         
           <div class='highlight'><pre><span class="function"><span class="title">run</span></span> = (args = process.argv) -&gt;
@@ -403,7 +359,7 @@ Parse options using <a href="https://github.com/visionmedia/commander.js">Comman
         
         
         
-          <div class='highlight'><pre>Docco = module.exports = {run, document, parse, version}</pre></div>
+          <div class='highlight'><pre>Docco = module.exports = {run, document, parse, configure, version}</pre></div>
         
       
       <div class="fleur">h</div>


### PR DESCRIPTION
I was upgrading a script which calls docco from 0.4.0 to the current version, and ran into an issue where I couldn't set any options (without running everything through commander) as `configure` is not exported.

Let me know if you'd rather I rework it so that sources can be passed into configure as `options.sources`, rather than `options.args`. (e.g. moving the args => sources transform into `run`).
