### PR TITLE
Callback

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -11,15 +11,13 @@
     return exec("mkdir -p " + config.output, function() {
       var complete, files, nextFile;
 
-      if (callback == null) {
-        callback = function(error) {
-          if (error) {
-            throw error;
-          }
-        };
-      }
+      callback || (callback = function(error) {
+        if (error) {
+          throw error;
+        }
+      });
       complete = function() {
-        return exec(["cp -f " + config.css + " " + config.output, fs.existsSync(config["public"]) ? "cp -fR " + config["public"] + " " + config.output : void 0].join('&&'), callback);
+        return exec(["cp -f " + config.css + " " + config.output, fs.existsSync(config["public"]) ? "cp -fR " + config["public"] + " " + config.output : void 0].join(' && '), callback);
       };
       files = config.sources.slice();
       nextFile = function() {

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -82,12 +82,12 @@ out in an HTML template.
 
       exec "mkdir -p #{config.output}", ->
 
-        callback ?= (error) -> throw error if error
-        complete  = ->
+        callback or= (error) -> throw error if error
+        complete   = ->
           exec [
             "cp -f #{config.css} #{config.output}"
             "cp -fR #{config.public} #{config.output}" if fs.existsSync config.public
-          ].join('&&'), callback
+          ].join(' && '), callback
 
         files = config.sources.slice()
 


### PR DESCRIPTION
Added a callback argument to the `document` function that will be called once _**all**_ asynchronous tasks have been completed.

Due to the current run-and-forget approach (which is understandable for optimizing run time), this wasn't as clean as I would have liked. This could easily be improved/simplified if all asynchronous jobs (or maybe just the directory copies) were made synchronous or the flow depended on their completed (i.e. nested callbacks - _yuck!_).

However, I hope it meets your standards. This should fix #166.
