### PR TITLE
Fix ReferenceError for Unknown Types

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -151,7 +151,7 @@
 
       lang = getLanguage(source, config);
       if (!lang) {
-        console.warn("docco: skipped unknown type (" + m + ")");
+        console.warn("docco: skipped unknown type (" + (path.basename(source)) + ")");
       }
       return lang;
     }).sort();

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -213,7 +213,7 @@ source files for languages for which we have definitions.
 
       config.sources = options.args.filter((source) ->
         lang = getLanguage source, config
-        console.warn "docco: skipped unknown type (#{m})" unless lang
+        console.warn "docco: skipped unknown type (#{path.basename source})" unless lang
         lang
       ).sort()
 


### PR DESCRIPTION
This fixes the `ReferenceError: m is not defined` currently being thrown when docco attempts to skip an unknown type.

I just printed out the file's basename (figuring that would be the most informative and least number of changed LOC), but if you want the extension instead, I'll update the PR.
