### PR TITLE
add support for block comments /** */ for .js

### DIFF
--- a/resources/languages.js
+++ b/resources/languages.js
@@ -1,4 +1,9 @@
-{ ".coffee":    {"name": "coffeescript", "symbol": "#"},
+/**
+It's easier to have this file in js and require it, vs parsing the json.
+For one, you can add usefule comments!
+*/
+module.exports = { 
+  ".coffee":    {"name": "coffeescript", "symbol": "#"},
   ".litcoffee": {"name": "coffeescript", "symbol": "#", "literate": true},
   ".ls":        {"name": "livescript", "symbol": "#"},
   ".rb":        {"name": "ruby", "symbol": "#"},
@@ -7,7 +12,12 @@
   ".yaml":      {"name": "yaml", "symbol": "#"},
   ".tex":       {"name": "tex", "symbol": "%"},
   ".latex":     {"name": "tex", "symbol": "%"},
-  ".js":        {"name": "javascript", "symbol": "//"},
+  ".js":        {
+    name: "javascript", 
+    symbol: "//", 
+    start_block: /^\/\x2a\x2a/,  // => "/**"
+    end_block: /^\x2a\//         // => "*/"
+  },
   ".java":      {"name": "java", "symbol": "//"},
   ".sass":      {"name": "sass", "symbol": "//"},
   ".scss":      {"name": "scss", "symbol": "//"},
@@ -26,4 +36,4 @@
   ".cs":        {"name": "c#", "symbol": "//"},
   ".scm":       {"name": "scheme", "symbol": ";;"},
   "Makefile":   {"name": "make", "symbol": "#"}
-}
+};


### PR DESCRIPTION
I extended the parse section to understand comment blocks, vs just single line comments.  Specifically, a valid comment block is wrapped by the following patterns at the start of a line.

/**

and 

*/
