### PR TITLE
added html to languages.json

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -25,5 +25,7 @@
   ".scala":     {"name": "scala", "symbol": "//"},
   ".cs":        {"name": "c#", "symbol": "//"},
   ".scm":       {"name": "scheme", "symbol": ";;"},
-  "Makefile":   {"name": "make", "symbol": "#"}
+  "Makefile":   {"name": "make", "symbol": "#"},
+  ".html":      {"name": "html", "symbol": ""},
+  ".htm":       {"name": "html", "symbol": ""}
 }


### PR DESCRIPTION
This might sound a bit absurd on first sight. Why include html on the list?

The answer is: because in some cases someone might want to write a markdown file with html source code examples inside. For example, the README of a jQuery plugin which does DOM manipulation.

But [source code inside .md files is not identified as code](https://github.com/jashkenas/docco/issues/179). You need to add an "extra" extension to the filename. So, instead of naming the file README.md, you name it README.js.md. The "extra" file extension identifies the language used on the source parts to the syntax highlighter, by looking inside languages.json again.

And this closes the circle. I'm adding html to the list, not because I want to pass html files directly to docco, but because some crazy people might want to write a `README.html.md` file.

Thanks a lot :)
