### PR TITLE
Fix and improve literal mode.

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -59,7 +59,7 @@
   };
 
   parse = function(source, code, config) {
-    var codeText, docsText, hasCode, i, lang, line, lines, match, prev, save, sections, _i, _j, _len, _len1;
+    var codeText, docsText, hasCode, i, isText, lang, line, lines, match, maybeCode, save, sections, _i, _j, _len, _len1;
 
     if (config == null) {
       config = {};
@@ -76,9 +76,10 @@
       return hasCode = docsText = codeText = '';
     };
     if (lang.literate) {
+      isText = maybeCode = true;
       for (i = _i = 0, _len = lines.length; _i < _len; i = ++_i) {
         line = lines[i];
-        lines[i] = /^\s*$/.test(line) ? '' : (match = /^([ ]{4}|\t)/.exec(line)) ? line.slice(match[0].length) : lang.symbol + ' ' + line;
+        lines[i] = maybeCode && (match = /^([ ]{4}|[ ]{0,3}\t)/.exec(line)) ? (isText = false, line.slice(match[0].length)) : (maybeCode = /^\s*$/.test(line)) ? isText ? lang.symbol : '' : (isText = true, lang.symbol + ' ' + line);
       }
     }
     for (_j = 0, _len1 = lines.length; _j < _len1; _j++) {
@@ -91,11 +92,9 @@
         if (/^(---+|===+)$/.test(line)) {
           save();
         }
-        prev = 'text';
       } else {
         hasCode = true;
         codeText += line + '\n';
-        prev = 'code';
       }
     }
     save();

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -126,12 +126,15 @@ invert the prose and code relationship on a per-line basis, and then continue as
 normal below.
 
       if lang.literate
+        isText = maybeCode = yes
         for line, i in lines
-          lines[i] = if /^\s*$/.test line
-            ''
-          else if match = (/^([ ]{4}|\t)/).exec line
+          lines[i] = if maybeCode and match = /^([ ]{4}|[ ]{0,3}\t)/.exec line
+            isText = no
             line[match[0].length..]
+          else if maybeCode = /^\s*$/.test line
+            if isText then lang.symbol else ''
           else
+            isText = yes
             lang.symbol + ' ' + line
 
       for line in lines
@@ -139,11 +142,9 @@ normal below.
           save() if hasCode
           docsText += (line = line.replace(lang.commentMatcher, '')) + '\n'
           save() if /^(---+|===+)$/.test line
-          prev = 'text'
         else
           hasCode = yes
           codeText += line + '\n'
-          prev = 'code'
       save()
 
       sections


### PR DESCRIPTION
Fix and improve literal mode.

As per [request](https://github.com/jashkenas/coffee-script/pull/2838#issuecomment-15020652) (Sorry for the wait):
- Require a blank line as delimiter between text and code.
- Don't ignore indentation with mixed whitespace.

Address issue with #190:  
- Treat blank lines as code or documentation, depending on preceding
  lines. This avoids starting a section for each blank line in
  documentation (which breaks markdown processing for lists).
- Remove an unused variable.

It would also be possible to combine the two loops (over `lines`), avoiding adding and then removing comments. Not quite sure if this fits your style though.
