### PR TITLE
Removed markdown

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -13,8 +13,6 @@
   ".hs":          {"name": "haskell", "symbol": "--"},
   ".erl":         {"name": "erlang", "symbol": "%"},
   ".hrl":         {"name": "erlang", "symbol": "%"},
-  ".md":          {"name": "markdown", "symbol": ""},
-  ".markdown":    {"name": "markdown", "symbol": ""},
   ".less":        {"name": "scss", "symbol": "//"},
   ".h":           {"name": "objectivec", "symbol": "//"},
   ".m":           {"name": "objectivec", "symbol": "//"},


### PR DESCRIPTION
Although I added the markdown language support I realise that it doesn't actually make sense in it's current state as it will only ever contain doc sections.

Markdown support could potentially be added again in the future to support more literate languages (see #152).
