### PR TITLE
Change output filename to include original extension

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -120,7 +120,7 @@
     var destination, first, hasTitle, html, title;
 
     destination = function(file) {
-      return path.join(config.output, path.basename(file, path.extname(file)) + '.html');
+      return path.join(config.output, file + '.html');
     };
     first = marked.lexer(sections[0].docsText)[0];
     hasTitle = first && first.type === 'heading' && first.depth === 1;

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -168,7 +168,7 @@ and rendering it to the specified output path.
     write = (source, sections, config) ->
 
       destination = (file) ->
-        path.join(config.output, path.basename(file, path.extname(file)) + '.html')
+        path.join(config.output, file + '.html')
 
 The **title** of the file is either the first heading in the prose, or the
 name of the source file.


### PR DESCRIPTION
Fixes #201

I prefer this method of naming files, but it's not backwards-compatible.

We might consider turning this into a command-line option instead of the default. Thoughts?
