### PR TITLE
Add support for cleaner TOC titles.

### DIFF
--- a/resources/classic/docco.jst
+++ b/resources/classic/docco.jst
@@ -19,8 +19,9 @@
           <div id="jump_page">
             <% for (var i=0, l=sources.length; i<l; i++) { %>
               <% var source = sources[i]; %>
+              <% var title = titles[i]; %>
               <a class="source" href="<%= path.basename(destination(source)) %>">
-                <%= path.basename(source) %>
+                <%= title %>
               </a>
             <% } %>
           </div>

--- a/resources/linear/docco.jst
+++ b/resources/linear/docco.jst
@@ -28,9 +28,10 @@
             <ol>
               <% for (var i=0, l = sources.length; i < l; i++) { %>
                 <% var source = sources[i]; %>
+                <% var title = titles[i]; %>
                 <li>
                   <a class="source" href="<%= path.basename(destination(source)) %>">
-                    <%= path.basename(source) %>
+                    <%= title %>
                   </a>
                 </li>
               <% } %>

--- a/resources/parallel/docco.jst
+++ b/resources/parallel/docco.jst
@@ -19,8 +19,9 @@
           <div id="jump_page">
             <% for (var i=0, l=sources.length; i<l; i++) { %>
               <% var source = sources[i]; %>
+              <% var title = titles[i]; %>
               <a class="source" href="<%= path.basename(destination(source)) %>">
-                <%= path.basename(source) %>
+                <%= title %>
               </a>
             <% } %>
           </div>


### PR DESCRIPTION
I'm not the most familiar with best practices for node.js, so bear with me on this pull request.

I wanted the Table of Contents to show the proper headers for the pages rather than the filenames. To do this I just run through the files in a prep pass to get the file titles. I then pass all of these titles to the templates so that they can render the nicer TOC.
