### PR TITLE
remove redundant background for div.content

### DIFF
--- a/resources/parallel/docco.css
+++ b/resources/parallel/docco.css
@@ -213,7 +213,6 @@ ul.sections > li > div {
   }
 
   ul.sections > li > div.content {
-    background: #f5f5ff;
     overflow-x:auto;
     -webkit-box-shadow: inset 0 0 5px #e5e5ee;
     box-shadow: inset 0 0 5px #e5e5ee;
@@ -314,7 +313,6 @@ ul.sections > li > div {
   ul.sections > li > div.content {
     padding: 13px;
     vertical-align: top;
-    background: #f5f5ff;
     border: none;
     -webkit-box-shadow: none;
     box-shadow: none;


### PR DESCRIPTION
`background: #F5F5FF` is already set as the body background, so specifying it on the divs themselves is redundant.
