### PR TITLE
Expose 'format' function

### DIFF
--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -296,4 +296,4 @@ Parse options using [Commander](https://github.com/visionmedia/commander.js).
 Public API
 ----------
 
-    Docco = module.exports = {run, document, parse, version}
+    Docco = module.exports = {run, document, parse, format, version}


### PR DESCRIPTION
I'm making an extension of docco that runs the template on the client side (same docs can be be viewed in different contexts + can use client side templates instead of jst). 

I only need to run 'parse' and 'format' for creating initial HTML sections object on the server side.
