### PR TITLE
Allow for scrolling if navigation list gets too big.

### DIFF
--- a/resources/parallel/docco.css
+++ b/resources/parallel/docco.css
@@ -166,14 +166,18 @@ ul.sections > li > div {
 
 #jump_to, #jump_wrapper {
   position: fixed;
-  right: 0; top: 0;
+  right: 0; 
+  top: 0;
   padding: 10px 15px;
-  margin:0;
+  margin: 0;
 }
 
 #jump_wrapper {
   display: none;
-  padding:0;
+  padding: 0;
+  bottom: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 #jump_to:hover #jump_wrapper {


### PR DESCRIPTION
Fixes the issue of not being able to see every doc file.
