### PR TITLE
Support multiple files with the same name.

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -122,24 +122,32 @@
   };
 
   write = function(source, sections, config) {
-    var destination, first, hasTitle, html, title;
+    var css, destination, first, hasTitle, html, relative, title;
     destination = function(file) {
-      return path.join(config.output, path.basename(file, path.extname(file)) + '.html');
+      return path.join(config.output, path.dirname(file), path.basename(file, path.extname(file)) + '.html');
+    };
+    relative = function(file) {
+      var from, to;
+      to = path.dirname(path.resolve(file));
+      from = path.dirname(path.resolve(destination(source)));
+      return path.join(path.relative(from, to), path.basename(file));
     };
     first = marked.lexer(sections[0].docsText)[0];
     hasTitle = first && first.type === 'heading' && first.depth === 1;
     title = hasTitle ? first.text : path.basename(source);
+    css = relative(path.join(config.output, path.basename(config.css)));
     html = config.template({
       sources: config.sources,
-      css: path.basename(config.css),
+      css: css,
       title: title,
       hasTitle: hasTitle,
       sections: sections,
       path: path,
-      destination: destination
+      destination: destination,
+      relative: relative
     });
     console.log("docco: " + source + " -> " + (destination(source)));
-    return fs.writeFileSync(destination(source), html);
+    return fs.outputFileSync(destination(source), html);
   };
 
   defaults = {

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -184,7 +184,12 @@ and rendering it to the specified output path.
     write = (source, sections, config) ->
 
       destination = (file) ->
-        path.join(config.output, path.basename(file, path.extname(file)) + '.html')
+        path.join(config.output, path.dirname(file), path.basename(file, path.extname(file)) + '.html')
+
+      relative = (file) ->
+        to = path.dirname(path.resolve(file))
+        from = path.dirname(path.resolve(destination(source)))
+        path.join(path.relative(from, to), path.basename(file))
 
 The **title** of the file is either the first heading in the prose, or the
 name of the source file.
@@ -192,12 +197,13 @@ name of the source file.
       first = marked.lexer(sections[0].docsText)[0]
       hasTitle = first and first.type is 'heading' and first.depth is 1
       title = if hasTitle then first.text else path.basename source
+      css = relative path.join(config.output, path.basename(config.css))
 
-      html = config.template {sources: config.sources, css: path.basename(config.css),
-        title, hasTitle, sections, path, destination,}
+      html = config.template {sources: config.sources, css,
+        title, hasTitle, sections, path, destination, relative}
 
       console.log "docco: #{source} -> #{destination source}"
-      fs.writeFileSync destination(source), html
+      fs.outputFileSync destination(source), html
 
 
 Configuration

--- a/resources/classic/docco.jst
+++ b/resources/classic/docco.jst
@@ -19,8 +19,8 @@
           <div id="jump_page">
             <% for (var i=0, l=sources.length; i<l; i++) { %>
               <% var source = sources[i]; %>
-              <a class="source" href="<%= path.basename(destination(source)) %>">
-                <%= path.basename(source) %>
+              <a class="source" href="<%= relative(destination(source)) %>">
+                <%= source %>
               </a>
             <% } %>
           </div>

--- a/resources/linear/docco.jst
+++ b/resources/linear/docco.jst
@@ -29,8 +29,8 @@
               <% for (var i=0, l = sources.length; i < l; i++) { %>
                 <% var source = sources[i]; %>
                 <li>
-                  <a class="source" href="<%= path.basename(destination(source)) %>">
-                    <%= path.basename(source) %>
+                  <a class="source" href="<%= relative(destination(source)) %>">
+                    <%= source %>
                   </a>
                 </li>
               <% } %>

--- a/resources/parallel/docco.jst
+++ b/resources/parallel/docco.jst
@@ -19,8 +19,8 @@
           <div id="jump_page">
             <% for (var i=0, l=sources.length; i<l; i++) { %>
               <% var source = sources[i]; %>
-              <a class="source" href="<%= path.basename(destination(source)) %>">
-                <%= path.basename(source) %>
+              <a class="source" href="<%= relative(destination(source)) %>">
+                <%= source %>
               </a>
             <% } %>
           </div>


### PR DESCRIPTION
Fixes #223.

Previously, if two or more files had the same base filename
only one would be documented. The others would be overwritten.

This patch replicates the structure of the source tree in the
document output tree to allow source files with the same
name but different paths.
