### PR TITLE
Added OpenGL Shading Language(GLSL) to the language list

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -61,6 +61,5 @@
   ".vhdl":        {"name": "vhdl", "symbol": "--"},
   ".glsl":        {"name": "glsl", "symbol": "//"},
   ".vert":        {"name": "glsl", "symbol": "//"},
-  ".frag":        {"name": "glsl", "symbol": "//"},
-  ".geom":        {"name": "glsl", "symbol": "//"}
+  ".frag":        {"name": "glsl", "symbol": "//"}
 }


### PR DESCRIPTION
Added GLSL language to the language list, although there is no official file extension for the OpenGL Shader files the most common ones are:
- .glsl
- .vert
- .frag
- .geom
