### PR TITLE
Adding repository field for npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "type":       "MIT",
     "url":        "http://opensource.org/licenses/mit-license.php"
   }],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jashkenas/docco.git"
+  },
   "engines": {
     "node":       ">=0.2.0"
   },


### PR DESCRIPTION
Adding the repository field to eliminate warnings on `npm install` and to make it easier for others to contribute.
