### PR TITLE
Correct meta viewport content syntax

### DIFF
--- a/resources/classic/docco.jst
+++ b/resources/classic/docco.jst
@@ -4,7 +4,7 @@
 <head>
   <title><%= title %></title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   <link rel="stylesheet" media="all" href="<%= css %>" />
 </head>
 <body>


### PR DESCRIPTION
The viewport content value should be comma-delimited, and it should not
have a final semicolon.

Chrome 31 gives warning messages about the current implementation:

```
The value "1.0;" for key "initial-scale" was truncated to its numeric prefix.
The value "1.0;" for key "maximum-scale" was truncated to its numeric prefix.
The value "0;" for key "user-scalable" was truncated to its numeric prefix.
Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.
```

This change fixes all 4 of those warnings.

Alex Gibson covers the proper syntax in ["Make sure to use correct meta
viewport syntax"][1]

[1] http://alxgbsn.co.uk/2011/11/23/make-sure-to-use-correct-meta-viewport-syntax/
