### PR TITLE
Support json (as javascript)

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -9,6 +9,7 @@
   ".sty":         {"name": "tex", "symbol": "%"},
   ".cls":         {"name": "tex", "symbol": "%"},
   ".js":          {"name": "javascript", "symbol": "//"},
+  ".json":        {"name": "javascript", "symbol": "//"},
   ".java":        {"name": "java", "symbol": "//"},
   ".groovy":      {"name": "groovy", "symbol": "//"},
   ".scss":        {"name": "scss", "symbol": "//"},


### PR DESCRIPTION
I think it's useful to be able to annotate json, so you can document configuration files or service schemas.

This simple fix makes that possible, but you should be aware this is hacky for two reasons:
- highlight.js does have a json format, but it didn't work for my sample.  I think it can only highlight full json objects and docco is sending it partial sections.
- JSON doesn't actually support comments, though many people wish it did (see [grunt-strip-json-comments](https://github.com/sindresorhus/grunt-strip-json-comments)).  I think it's safe to assume javascript-style comments are intentional when using it with docco
