### PR TITLE
add .npmignore to reduce npm package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git*
+Cakefile
+docco.litcoffee
+index.html


### PR DESCRIPTION
A new release would after merging would be appreciated.
