### PR TITLE
Use first heading even if there is a line of code first

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -129,7 +129,9 @@
     firstSection = _.find(sections, function(section) {
       return section.docsText.length > 0;
     });
-    first = marked.lexer(firstSection.docsText)[0];
+    if (firstSection) {
+      first = marked.lexer(firstSection.docsText)[0];
+    }
     hasTitle = first && first.type === 'heading' && first.depth === 1;
     title = hasTitle ? first.text : path.basename(source);
     html = config.template({

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -191,7 +191,7 @@ name of the source file.
 
       firstSection = _.find sections, (section) ->
         section.docsText.length > 0
-      first = marked.lexer(firstSection.docsText)[0]
+      first = marked.lexer(firstSection.docsText)[0] if firstSection
       hasTitle = first and first.type is 'heading' and first.depth is 1
       title = if hasTitle then first.text else path.basename source
 


### PR DESCRIPTION
Proposes a fix for issue #265.

It works in so far that you don't see two headings if your file starts with something like

```
<?php
// # My Heading
```

However, `My Heading` will not be displayed at the top of the file (and uncommented `<?php`) will appear first. To fix that, you would somehow have to remove the HTML of the first heading from its own section. I wasn't really sure what the cleanest way to do that would be, so I left it as is.
