### PR TITLE
Added scrolling to the jump menu

### DIFF
--- a/resources/parallel/docco.css
+++ b/resources/parallel/docco.css
@@ -183,6 +183,8 @@ ul.sections > li > div {
 #jump_page {
   padding: 5px 0 3px;
   margin: 0 0 25px 25px;
+  max-height: 400px;
+  overflow: auto;
 }
 
 #jump_page .source {


### PR DESCRIPTION
Made the parallel menu capable of being bigger than the screen by adding scrolling to it.
