### PR TITLE
Add ".cson" to languages

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -1,6 +1,7 @@
 { ".coffee":      {"name": "coffeescript", "symbol": "#"},
   ".litcoffee":   {"name": "coffeescript", "symbol": "#", "literate": true},
   "Cakefile":     {"name": "coffeescript", "symbol": "#"},
+  ".cson":        {"name": "coffeescript", "symbol": "#"},
   ".rb":          {"name": "ruby", "symbol": "#"},
   ".py":          {"name": "python", "symbol": "#"},
   ".tex":         {"name": "tex", "symbol": "%"},


### PR DESCRIPTION
> Same as JSON but for CoffeeScript objects.

See https://github.com/bevry/cson.

Would be really great to have this in `docco`, e.g. to document (`grunt`) build process configs like so
![screen shot 2014-03-26 at 10 15 41](https://cloud.githubusercontent.com/assets/425211/2534748/60848510-b581-11e3-93a4-376c627b400f.png)
