### PR TITLE
feat: add support for plain C

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -4,6 +4,7 @@
   ".as":          {"name": "actionscript", "symbol": "//"},
   ".bat":         {"name": "dos", "symbol": "@?rem"},
   ".btm":         {"name": "dos", "symbol": "@?rem"},
+  ".c":           {"name": "c", "symbol": "//"},
   ".clj":         {"name": "clojure", "symbol": ";"},
   ".cls":         {"name": "tex", "symbol": "%"},
   ".cmake":       {"name": "cmake", "symbol": "#"},


### PR DESCRIPTION
Add support for plain C files. C++ was allowed, but C was not.
