### PR TITLE
docco.parse: Don't crash if config parameter is default value.

### DIFF
--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -295,7 +295,7 @@ file extension. Detect and tag "literate" `.ext.md` variants.
 
     getLanguage = (source, config) ->
       ext  = config.extension or path.extname(source) or path.basename(source)
-      lang = config.languages[ext] or languages[ext]
+      lang = config.languages?[ext] or languages[ext]
       if lang and lang.name is 'markdown'
         codeExt = path.extname(path.basename(source, ext))
         if codeExt and codeLang = languages[codeExt]


### PR DESCRIPTION
The signature of `docco.parse` is `(source, code, config={})` but `getLanguage` crashes if config is {}.  Fix this.

This is a regression which appeared in bb4df7546b248adc47db89d5660d5533148b5fc1 (docco 0.6.3).  In docco 0.6.2 the signature of `docco.parse` was `(source, code)` and it didn't crash.
