### PR TITLE
Add .jsm suffix for Mozilla JavaScript modules

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -25,6 +25,7 @@
   ".hs":          {"name": "haskell", "symbol": "--"},
   ".ini":         {"name": "ini", "symbol": ";"},
   ".js":          {"name": "javascript", "symbol": "//"},
+  ".jsm":         {"name": "javascript", "symbol": "//"},
   ".jsx":         {"name": "javascript", "symbol": "//"},
   ".java":        {"name": "java", "symbol": "//"},
   ".latex":       {"name": "tex", "symbol": "%"},


### PR DESCRIPTION
These modules are traditionally suffixed .jsm instead of .js. See for example:
https://stackoverflow.com/questions/2591368/jsm-vs-js-files
