### PR TITLE
Keep inline comments for literate languages inline.

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -211,7 +211,12 @@
     var ext, l;
     for (ext in languages) {
       l = languages[ext];
-      l.commentMatcher = RegExp("^\\s*" + l.symbol + "\\s?");
+      if (l.literate) {
+        console.log("literate");
+        l.commentMatcher = RegExp("^" + l.symbol + "(?!([ ]{4}|[ ]{0,3}\\t)*" + l.symbol + ")\\s?");
+      } else {
+        l.commentMatcher = RegExp("^\\s*" + l.symbol + "\\s?");
+      }
       l.commentFilter = /(^#![/]|^\s*#\{)/;
     }
     return languages;

--- a/docco.js
+++ b/docco.js
@@ -212,8 +212,7 @@
     for (ext in languages) {
       l = languages[ext];
       if (l.literate) {
-        console.log("literate");
-        l.commentMatcher = RegExp("^" + l.symbol + "(?!([ ]{4}|[ ]{0,3}\\t)*" + l.symbol + ")\\s?");
+        l.commentMatcher = RegExp("^" + l.symbol);
       } else {
         l.commentMatcher = RegExp("^\\s*" + l.symbol + "\\s?");
       }

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -281,8 +281,8 @@ Build out the appropriate matchers and delimiters for each language.
       for ext, l of languages
 
 Is the line prose? Note that because of the way we preprocess literate languages, and
-because we want to leave the inline comments inline for those, it's much simpler to identify
-which comments are intended to be prose.
+because we want to leave the inline comments inline for them, we ignore comments that
+have preceeding whitespace.
 
         if l.literate then l.commentMatcher = ///^#{l.symbol}///
         else l.commentMatcher = ///^\s*#{l.symbol}\s?///

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -280,9 +280,11 @@ Build out the appropriate matchers and delimiters for each language.
     buildMatchers = (languages) ->
       for ext, l of languages
 
-Does the line begin with a comment?
+Is the line a comment? Note that because of how we handle literate code, the matcher is a bit
+more complex as we want to leave inline comments inline.
 
-        l.commentMatcher = ///^\s*#{l.symbol}\s?///
+        if l.literate then l.commentMatcher = ///^#{l.symbol}(?!([\ ]{4}|[\ ]{0,3}\t)*#{l.symbol})\s?///
+        else l.commentMatcher = ///^\s*#{l.symbol}\s?///
 
 Ignore [hashbangs](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) and interpolations...
 

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -280,10 +280,11 @@ Build out the appropriate matchers and delimiters for each language.
     buildMatchers = (languages) ->
       for ext, l of languages
 
-Is the line a comment? Note that because of how we handle literate code, the matcher is a bit
-more complex as we want to leave inline comments inline.
+Is the line prose? Note that because of the way we preprocess literate languages, and
+because we want to leave the inline comments inline for those, it's much simpler to identify
+which comments are intended to be prose.
 
-        if l.literate then l.commentMatcher = ///^#{l.symbol}(?!([\ ]{4}|[\ ]{0,3}\t)*#{l.symbol})\s?///
+        if l.literate then l.commentMatcher = ///^#{l.symbol}///
         else l.commentMatcher = ///^\s*#{l.symbol}\s?///
 
 Ignore [hashbangs](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) and interpolations...


### PR DESCRIPTION
Because literate languages specifically separate code comments from prose, pulling those comments out makes the resulting document disjointed and harder to read.

As such, we should leave them where they are. Because of the way docco preprocesses literate files, we can separate the prose simply by only using lines that _start_ with the comment symbol.

This fixes #262
