### PR TITLE
style(linear): improves the title and toc of the linear layout

### DIFF
--- a/resources/linear/docco.css
+++ b/resources/linear/docco.css
@@ -66,6 +66,8 @@ h1, h2, h3, h4, h5, h6 {
   h1 {
     margin: 0;
     text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   h2 {
     font-size: 1.3em;
@@ -169,7 +171,7 @@ ul.sections {
 
 .toc {
   max-height: 0;
-  overflow: hidden;
+  overflow: auto;
   text-align: center;
   font-size: 13px;
   line-height: 20px;


### PR DESCRIPTION
This makes the overflowed text in h1 ellipsis dots, and allows the toc to scroll when there are more files than fit comfortably in the 500px max-height given it.
