### PR TITLE
Passes language to the template

### DIFF
--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -206,7 +206,7 @@ name of the source file.
       title = if hasTitle then first.text else path.basename source
 
       html = config.template {sources: config.sources, css: path.basename(config.css),
-        title, hasTitle, sections, path, destination, language: getLanguage(source, config),}
+        title, hasTitle, sections, path, destination, language: getLanguage(source, config)}
 
       console.log "docco: #{source} -> #{destination source}"
       fs.writeFileSync destination(source), html


### PR DESCRIPTION
This can be used for markdown templates to inject appropriate syntax highlighting tags.
