### PR TITLE
added blank css file to plain-markdown layout directory

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -20,7 +20,7 @@
         if (fs.existsSync(file)) {
           return fs.copy(file, path.join(config.output, path.basename(file)), callback);
         } else {
-          return callback;
+          return callback();
         }
       };
       complete = function() {

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -85,7 +85,7 @@ out in an HTML template.
         callback or= (error) -> throw error if error
         copyAsset  = (file, callback) ->
           if fs.existsSync file then fs.copy file, path.join(config.output, path.basename(file)), callback
-          else callback
+          else callback()
         complete   = ->
           copyAsset config.css, (error) ->
             if error then callback error


### PR DESCRIPTION
When using the `-l plain-markdown` option in docco, it was expecting this file. I figured this would be the quicker, dirtier way to make it work properly, but alternatively we could check if the docco.css file exists before trying to use it.
