### PR TITLE
Tab Replacement

### DIFF
--- a/docco.js
+++ b/docco.js
@@ -113,7 +113,7 @@
       highlight: function(code, lang) {
         lang || (lang = language.name);
         if (highlightjs.getLanguage(lang)) {
-          return highlightjs.highlight(lang, code).value;
+          return highlightjs.fixMarkup(highlightjs.highlight(lang, code).value);
         } else {
           console.warn("docco: couldn't highlight code block with unknown language '" + lang + "' in " + source);
           return code;
@@ -124,7 +124,7 @@
     for (i = _i = 0, _len = sections.length; _i < _len; i = ++_i) {
       section = sections[i];
       code = highlightjs.highlight(language.name, section.codeText).value;
-      code = code.replace(/\s+$/, '');
+      code = highlightjs.fixMarkup(code).replace(/\s+$/, '');
       section.codeHtml = "<div class='highlight'><pre>" + code + "</pre></div>";
       _results.push(section.docsHtml = marked(section.docsText));
     }
@@ -241,6 +241,10 @@
   };
 
   version = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'))).version;
+
+  highlightjs.configure({
+    tabReplace: '  '
+  });
 
   run = function(args) {
     var c;

--- a/docco.litcoffee
+++ b/docco.litcoffee
@@ -176,7 +176,7 @@ if not specified.
           lang or= language.name
 
           if highlightjs.getLanguage(lang)
-            highlightjs.highlight(lang, code).value
+            highlightjs.fixMarkup highlightjs.highlight(lang, code).value
           else
             console.warn "docco: couldn't highlight code block with unknown language '#{lang}' in #{source}"
             code
@@ -184,7 +184,7 @@ if not specified.
 
       for section, i in sections
         code = highlightjs.highlight(language.name, section.codeText).value
-        code = code.replace(/\s+$/, '')
+        code = highlightjs.fixMarkup(code).replace /\s+$/, ''
         section.codeHtml = "<div class='highlight'><pre>#{code}</pre></div>"
         section.docsHtml = marked(section.docsText)
 
@@ -315,6 +315,10 @@ Keep it DRY. Extract the docco **version** from `package.json`
 
     version = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'))).version
 
+Tabs are replaced by two spaces in the output.
+
+    highlightjs.configure
+      tabReplace: '  '
 
 Command Line Interface
 ----------------------


### PR DESCRIPTION
[This PR](https://github.com/jashkenas/docco/pull/60) was submitted in 2011 to change the default code output's tab width to 2. Now that Pygments is no longer used, the change has been removed and the default has gone back to 8 spaces.

I've added the highlight.js config to do the equivalent of that Pygments PR. I'm not sure on docs convention, so let me know if you want the text to be changed :)