### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "keywords":     ["documentation", "docs", "generator", "literate", "coffeescript"],
   "author":       "Jeremy Ashkenas",
   "version":      "0.7.0",
-  "licenses": [{
-    "type":       "MIT",
-    "url":        "http://opensource.org/licenses/mit-license.php"
-  }],
+  "license":      "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jashkenas/docco.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/