### PR TITLE
The rocco and shocco projects are broken for a number of years. Both seem abandoned.

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,15 +55,6 @@ language is also supported — just tack an <code>.md</code> extension on the en
       
         
         <ul>
-<li><p>If Node.js doesn’t run on your platform, or you’d prefer a more
-convenient package, get <a href="http://github.com/rtomayko">Ryan Tomayko</a>‘s
-<a href="http://rtomayko.github.io/rocco/rocco.html">Rocco</a>, the <strong>Ruby</strong> port that’s
-available as a gem.</p>
-</li>
-<li><p>If you’re writing shell scripts, try
-<a href="http://rtomayko.github.io/shocco/">Shocco</a>, a port for the <strong>POSIX shell</strong>,
-also by Mr. Tomayko.</p>
-</li>
 <li><p>If <strong>Python</strong> is more your speed, take a look at
 <a href="http://github.com/fitzgen">Nick Fitzgerald</a>‘s <a href="http://fitzgen.github.io/pycco/">Pycco</a>.</p>
 </li>


### PR DESCRIPTION
Please remove the references to the rocco and shocco projects. Both are currently broken and their respective projects apparently abandoned.  At a minimum both seem to generate docs with hardcoded paths to CSS files which point to this repository.  Paths which have changed and broken over the years.  Both have primary homepages which are to act as demos, and both are unstyled for years as a result.

I have also filed an issue on the rocco project to ask that the project be marked as no longer supported.

https://github.com/rtomayko/rocco/issues/107

If it were not for the links on this docco main site I would not have gone down that path and wasted some time in the process of discovery as to why it was broken.

Thanks!