### PR TITLE
Parallel layout code is aligned to the bottom

### DIFF
--- a/resources/parallel/docco.css
+++ b/resources/parallel/docco.css
@@ -324,10 +324,10 @@ ul.sections > li > div {
 
   ul.sections > li > div.content {
     padding: 13px;
-    vertical-align: top;
     border: none;
     -webkit-box-shadow: none;
     box-shadow: none;
+    vertical-align: bottom;
   }
 
   .pilwrap {


### PR DESCRIPTION
Often code will get raised above it's section header in the parallel layout. Since code is a second class citizen, it should be read after the corresponding comment. This changes the code block's vertical alignment to be at the bottom of the code/comment block rather than the top.

Feel free to reject this if you disagree.
