### PR TITLE
Adds .es6 extension

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -17,6 +17,7 @@
   ".d":           {"name": "d", "symbol": "//"},
   ".dtx":         {"name": "tex", "symbol": "%"},
   ".erl":         {"name": "erlang", "symbol": "%"},
+  ".es6":         {"name": "javascript", "symbol": "//"},  
   ".frag":        {"name": "glsl", "symbol": "//"},
   ".glsl":        {"name": "glsl", "symbol": "//"},
   ".go":          {"name": "go", "symbol": "//"},


### PR DESCRIPTION
Since many people opt to use this extension to avoid unnecessary compiling steps when including regular `.js` nowadays.