### PR TITLE
Support filtering of alternative comment symbols

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -26,7 +26,7 @@
   ".hs":          {"name": "haskell", "symbol": "--"},
   ".ini":         {"name": "ini", "symbol": ";"},
   ".jade":        {"name": "jade", "symbol": "//-"},
-  ".js":          {"name": "javascript", "symbol": "//"},
+  ".js":          {"name": "javascript", "symbol": "//", "altSymbol": "*"},
   ".jsm":         {"name": "javascript", "symbol": "//"},
   ".jsx":         {"name": "javascript", "symbol": "//"},
   ".java":        {"name": "java", "symbol": "//"},


### PR DESCRIPTION
E.g. when documenting a REST API (apiDoc.js) with one type of symbols and the source with another (/\* */ vs. //).
