### PR TITLE
Add .lualit to supported types

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -36,6 +36,7 @@
   ".litcoffee":   {"name": "coffeescript", "symbol": "#", "literate": true},
   ".ls":          {"name": "coffeescript", "symbol": "#"},
   ".lua":         {"name": "lua", "symbol": "--"},
+  ".lualit":      {"name": "lua", "symbol": "--", "literate": true},
   ".n":           {"name": "nemerle", "symbol": "//"},
   ".m":           {"name": "objectivec", "symbol": "//"},
   ".mel":         {"name": "mel", "symbol": "//"},


### PR DESCRIPTION
[Lualit is literate Lua](https://github.com/gordonbrander/lualit) in the spirit of Literate Coffeescript. Docco supports compiling literate Lua via `.lua.md`. This PR adds support for the `.lualit` file extension.