### PR TITLE
Replaces meta element key-value pair separator ; -> ,

### DIFF
--- a/resources/parallel/docco.jst
+++ b/resources/parallel/docco.jst
@@ -4,7 +4,7 @@
 <head>
   <title><%= title %></title>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   <link rel="stylesheet" media="all" href="<%= css %>" />
 </head>
 <body>


### PR DESCRIPTION
When browsing documentation pages generated with docco, such as `http://coffeescript.org/v1/annotated-source/`,
Chrome 57.0 returns the following console error:
Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.
This PR fixes the syntax to resolve this error.