### PR TITLE
feature(languages.json): add support for `.hpp`

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -25,6 +25,7 @@
   ".go":          {"name": "go", "symbol": "//"},
   ".groovy":      {"name": "groovy", "symbol": "//"},
   ".h":           {"name": "objectivec", "symbol": "//"},
+  ".hpp":         {"name": "cpp", "symbol": "//"},
   ".hrl":         {"name": "erlang", "symbol": "%"},
   ".hs":          {"name": "haskell", "symbol": "--"},
   ".ini":         {"name": "ini", "symbol": ";"},


### PR DESCRIPTION
This extension is used by many C++ projects (e.g. Boost).