### PR TITLE
Cleanup whitespace in plain-markdown template

### DIFF
--- a/resources/plain-markdown/docco.jst
+++ b/resources/plain-markdown/docco.jst
@@ -1,15 +1,4 @@
-<% for (var i = 0, l = sections.length; i<l; i++) { %>
-
-<% var section = sections[i]; %>
-
-<%= section.docsText %>
-
-<% if (!(/^\s*$/).test(section.codeText)) { %>  
-
-```
-<%= section.codeText %>
-```
-
+<% for (var i = 0, l = sections.length; i<l; i++) { %><% var section = sections[i]; %><%= section.docsText %><% if (!(/^\s*$/).test(section.codeText)) { %>
+```<%= section.codeText %>```
 <% } %>
-
 <% } %>


### PR DESCRIPTION
This makes for nicer READMEs