### PR TITLE
rust: account for doc comment syntax

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -78,8 +78,8 @@
   ".vim":         {"name": "vim", "symbol": "\""},
   ".vue":         {"name": "vuejs", "symbol": "//"},
   ".r":           {"name": "r", "symbol": "#"},
-  ".rc":          {"name": "rust", "symbol": "//"},
-  ".rs":          {"name": "rust", "symbol": "//"},
+  ".rc":          {"name": "rust", "symbol": "///?"},
+  ".rs":          {"name": "rust", "symbol": "///?"},
   ".wsc":         {"name": "vbscript", "symbol": "'"},
   ".wsf":         {"name": "vbscript", "symbol": "'"},
   ".yaml":        {"name": "yaml", "symbol": "#"}


### PR DESCRIPTION
Rust has two flavors of comment, the plain line comment (`//`) and the doc
comment (`///`).  Rustdoc, the native documentation tool, renders only doc
comments (`///`).

docco now searches for both `//` comments and `///` comments in Rust source
files.  Previously, it had only searched for `//` comments, so `///` comments
were rendered with an ugly superfluous `/` at the start of their content.