### PR TITLE
Adds Dart support to languages.json

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -17,6 +17,7 @@
   ".cs":          {"name": "cs", "symbol": "//"},
   ".cson":        {"name": "coffeescript", "symbol": "#"},
   ".d":           {"name": "d", "symbol": "//"},
+  ".dart":        {"name": "dart", "symbol": "///"},
   ".dtx":         {"name": "tex", "symbol": "%"},
   ".erl":         {"name": "erlang", "symbol": "%"},
   ".f":           {"name": "fortran", "symbol": "!"},


### PR DESCRIPTION
Adds [Dart](https://dart.dev) support to `languages.json`

Reference for doc comments [here](https://dart.dev/guides/language/effective-dart/documentation#doc-comments).

