### PR TITLE
fix marked dependency (#417)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "commander":  ">= 0.5.2",
-    "marked":     ">= 0.2.7",
+    "marked":     "^0.3.19",
     "fs-extra":   ">= 0.6.0",
     "underscore": ">= 1.0.0",
     "highlight.js": ">= 8.0.x"


### PR DESCRIPTION
Hey—I want to write a tutorial about extending the Controller class for [lil-gui](https://github.com/georgealways/lil-gui) and I remembered this classic lib...

I just changed the `marked` dep to the oldest version that doesn't have a vulnerability warning and docco is generating docs again. Tried italicizing something, seems like markdown is still working as well. This is on the latest node 16.13.