### PR TITLE
Update marked from 4.0.3 to 4.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "marked": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.3.tgz",
-      "integrity": "sha512-vSwKKtw+lCA0uFK/02JT4tBfNxEREpoTg21NoXqcmX0ySBIEyLMYWmt8WPsM61QNFaDBZkggupyNXLsV7uPuRg=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw=="
     },
     "underscore": {
       "version": "1.13.1",


### PR DESCRIPTION
Also, you should turn on Dependabot to keep your dependencies up to date.