### PR TITLE
Add Kotlin support

### DIFF
--- a/resources/languages.json
+++ b/resources/languages.json
@@ -37,6 +37,7 @@
   ".json5":       {"name": "javascript", "symbol": "//"},
   ".jsx":         {"name": "javascript", "symbol": "//"},
   ".java":        {"name": "java", "symbol": "//"},
+  ".kt":          {"name": "kotlin", "symbol": "//"},
   ".latex":       {"name": "tex", "symbol": "%"},
   ".less":        {"name": "less", "symbol": "//"},
   ".lisp":        {"name": "lisp", "symbol": ";"},


### PR DESCRIPTION
## Summary
Adds Kotlin (`.kt`) file extension support to Docco's language definitions.

## Changes
- Added `.kt` extension mapping in `resources/languages.json`
- Uses `kotlin` as the language name (supported by Highlight.js)
- Uses `//` for single-line comments (same as Java/JavaScript/C++)

## Testing
Tested with Kotlin codebases at [Firecode.io](https://firecode.io) and
generates documentation successfully with proper syntax highlighting via
Highlight.js.